### PR TITLE
add fuse mount subtype to mountconfig

### DIFF
--- a/mount_config.go
+++ b/mount_config.go
@@ -142,6 +142,8 @@ type MountConfig struct {
 	// For expert use only! May invalidate other guarantees made in the
 	// documentation for this package.
 	Options map[string]string
+
+	SubType string
 }
 
 // Create a map containing all of the key=value mount options to be given to
@@ -171,6 +173,11 @@ func (c *MountConfig) toMap() (opts map[string]string) {
 	// Special file system name?
 	if fsname != "" {
 		opts["fsname"] = fsname
+	}
+
+	subtype := c.SubType
+	if subtype != "" {
+		opts["subtype"] = subtype
 	}
 
 	// Read only?

--- a/mount_config.go
+++ b/mount_config.go
@@ -143,7 +143,10 @@ type MountConfig struct {
 	// documentation for this package.
 	Options map[string]string
 
-	SubType string
+	// Sets the filesystem type (third field in /etc/mtab). /etc/mtab and
+	// /proc/mounts will show the filesystem type as fuse.<Subtype>.
+	// If not set, /proc/mounts will show the filesystem type as fuse/fuseblk.
+	Subtype string
 }
 
 // Create a map containing all of the key=value mount options to be given to
@@ -175,7 +178,7 @@ func (c *MountConfig) toMap() (opts map[string]string) {
 		opts["fsname"] = fsname
 	}
 
-	subtype := c.SubType
+	subtype := c.Subtype
 	if subtype != "" {
 		opts["subtype"] = subtype
 	}


### PR DESCRIPTION
when want to mount jacobsa based filesystem,
we can use command like " mount -t goofys -o allow_other,debug http://cs6:6081:newbucket9 /mnt/s3
"
when mounted,the cmd mount will be "http://127.0.0.1:8080:goofys-test-terrrr on /mnt/s3 type **fuse** (rw,nosuid,nodev,relatime,user_id=0,group_id=0,default_permissions)
"
If not set subtype value by filesystem goofys,the output will be that the type is fuse.
If set subtype value as goofys by filesystem goofys. the output will be "http://127.0.0.1:8080:goofys-test-terrrr on /mnt/s3 type **fuse.goofys** (rw,nosuid,nodev,relatime,user_id=0,group_id=0,default_permissions)"
