### PR TITLE
Hard links implementation

### DIFF
--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -317,6 +317,26 @@ type CreateSymlinkOp struct {
 	Entry ChildInodeEntry
 }
 
+// Create a hard link to an inode. If the name already exists, the file system
+// should return EEXIST (cf. the notes on CreateFileOp and MkDirOp).
+type CreateLinkOp struct {
+	// The ID of parent directory inode within which to create the child hard
+	// link.
+	Parent InodeID
+
+	// The name of the new inode.
+	Name string
+
+	// The ID of the target inode.
+	Target InodeID
+
+	// Set by the file system: information about the inode that was created.
+	//
+	// The lookup count for the inode is implicitly incremented. See notes on
+	// ForgetInodeOp for more information.
+	Entry ChildInodeEntry
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Unlinking
 ////////////////////////////////////////////////////////////////////////

--- a/fusetesting/parallel.go
+++ b/fusetesting/parallel.go
@@ -365,3 +365,71 @@ func RunSymlinkInParallelTest(
 		AssertEq(nil, err)
 	}
 }
+
+// Run an ogletest test that checks expectations for parallel calls to
+// link(2).
+func RunHardlinkInParallelTest(
+	ctx context.Context,
+	dir string) {
+	// Ensure that we get parallelism for this test.
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(runtime.NumCPU()))
+
+	// Create a file.
+	originalFile := path.Join(dir, "original_file")
+	const contents = "Hello\x00world"
+
+	err := ioutil.WriteFile(originalFile, []byte(contents), 0444)
+	AssertEq(nil, err)
+
+	// Try for awhile to see if anything breaks.
+	const duration = 500 * time.Millisecond
+	startTime := time.Now()
+	for time.Since(startTime) < duration {
+		filename := path.Join(dir, "foo")
+
+		// Set up a function that creates the symlink, ignoring EEXIST errors.
+		worker := func(id byte) (err error) {
+			err = os.Link(originalFile, filename)
+
+			if os.IsExist(err) {
+				err = nil
+			}
+
+			if err != nil {
+				err = fmt.Errorf("Worker %d: Link: %v", id, err)
+				return
+			}
+
+			return
+		}
+
+		// Run several workers in parallel.
+		const numWorkers = 16
+		b := syncutil.NewBundle(ctx)
+		for i := 0; i < numWorkers; i++ {
+			id := byte(i)
+			b.Add(func(ctx context.Context) (err error) {
+				err = worker(id)
+				return
+			})
+		}
+
+		err := b.Join()
+		AssertEq(nil, err)
+
+		// The symlink should have been created, once.
+		entries, err := ReadDirPicky(dir)
+		AssertEq(nil, err)
+		AssertEq(2, len(entries))
+		AssertEq("foo", entries[0].Name())
+		AssertEq("original_file", entries[1].Name())
+
+		// Remove the link.
+		err = os.Remove(filename)
+		AssertEq(nil, err)
+	}
+
+	// Clean up the original file at the end.
+	err = os.Remove(originalFile)
+	AssertEq(nil, err)
+}

--- a/fuseutil/file_system.go
+++ b/fuseutil/file_system.go
@@ -43,6 +43,7 @@ type FileSystem interface {
 	MkDir(context.Context, *fuseops.MkDirOp) error
 	MkNode(context.Context, *fuseops.MkNodeOp) error
 	CreateFile(context.Context, *fuseops.CreateFileOp) error
+	CreateLink(context.Context, *fuseops.CreateLinkOp) error
 	CreateSymlink(context.Context, *fuseops.CreateSymlinkOp) error
 	Rename(context.Context, *fuseops.RenameOp) error
 	RmDir(context.Context, *fuseops.RmDirOp) error
@@ -158,6 +159,9 @@ func (s *fileSystemServer) handleOp(
 
 	case *fuseops.CreateFileOp:
 		err = s.fs.CreateFile(ctx, typed)
+
+	case *fuseops.CreateLinkOp:
+		err = s.fs.CreateLink(ctx, typed)
 
 	case *fuseops.CreateSymlinkOp:
 		err = s.fs.CreateSymlink(ctx, typed)

--- a/fuseutil/not_implemented_file_system.go
+++ b/fuseutil/not_implemented_file_system.go
@@ -92,6 +92,13 @@ func (fs *NotImplementedFileSystem) CreateSymlink(
 	return
 }
 
+func (fs *NotImplementedFileSystem) CreateLink(
+	ctx context.Context,
+	op *fuseops.CreateLinkOp) (err error) {
+	err = fuse.ENOSYS
+	return
+}
+
 func (fs *NotImplementedFileSystem) Rename(
 	ctx context.Context,
 	op *fuseops.RenameOp) (err error) {

--- a/samples/memfs/posix_test.go
+++ b/samples/memfs/posix_test.go
@@ -445,3 +445,7 @@ func (t *PosixTest) MkdirInParallel() {
 func (t *PosixTest) SymlinkInParallel() {
 	fusetesting.RunSymlinkInParallelTest(t.ctx, t.dir)
 }
+
+func (t *PosixTest) HardlinkInParallel() {
+	fusetesting.RunHardlinkInParallelTest(t.ctx, t.dir)
+}


### PR DESCRIPTION
In some situations it's very useful to have hard links in FUSE based file system.
This change will allow the hard links creation.

The change contains very minimal piece of code required to make OpLink operation possible:
- new CreateLinkOp struct is introduced and CreateLink call is added to FileSystem interface,
- code for serialization and deserialization is implemented for the new operation.
