### PR TITLE
replace imports of "golang.org/x/net/context" with "context"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       language: go
-      go: 1.8.1
+      go: 1.9.3
       # Use the virtualized Trusty beta Travis is running in order to get
       # support for installing fuse.
       #
@@ -14,7 +14,7 @@ matrix:
       sudo: required
     - os: osx
       language: go
-      go: 1.8.1
+      go: 1.9.3
 
 # Install fuse before installing our code.
 before_install:

--- a/connection.go
+++ b/connection.go
@@ -15,6 +15,7 @@
 package fuse
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -23,8 +24,6 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/internal/buffer"

--- a/fusetesting/parallel.go
+++ b/fusetesting/parallel.go
@@ -15,6 +15,7 @@
 package fusetesting
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -25,7 +26,6 @@ import (
 
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/syncutil"
-	"golang.org/x/net/context"
 )
 
 // Run an ogletest test that checks expectations for parallel calls to open(2)

--- a/fuseutil/file_system.go
+++ b/fuseutil/file_system.go
@@ -15,10 +15,9 @@
 package fuseutil
 
 import (
+	"context"
 	"io"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/fuseutil/not_implemented_file_system.go
+++ b/fuseutil/not_implemented_file_system.go
@@ -15,9 +15,10 @@
 package fuseutil
 
 import (
+	"context"
+
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"
-	"golang.org/x/net/context"
 )
 
 // A FileSystem that responds to all ops with fuse.ENOSYS. Embed this in your

--- a/mount.go
+++ b/mount.go
@@ -15,10 +15,9 @@
 package fuse
 
 import (
+	"context"
 	"fmt"
 	"os"
-
-	"golang.org/x/net/context"
 )
 
 // Server is an interface for any type that knows how to serve ops read from a

--- a/mount_config.go
+++ b/mount_config.go
@@ -15,12 +15,11 @@
 package fuse
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"runtime"
 	"strings"
-
-	"golang.org/x/net/context"
 )
 
 // Optional configuration accepted by Mount.

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,14 +1,13 @@
 package fuse_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/mounted_file_system.go
+++ b/mounted_file_system.go
@@ -14,7 +14,7 @@
 
 package fuse
 
-import "golang.org/x/net/context"
+import "context"
 
 // MountedFileSystem represents the status of a mount operation, with a method
 // that waits for unmounting.

--- a/samples/cachingfs/caching_fs.go
+++ b/samples/cachingfs/caching_fs.go
@@ -15,13 +15,12 @@
 package cachingfs
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io"
 	"os"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/dynamicfs/dynamic_fs.go
+++ b/samples/dynamicfs/dynamic_fs.go
@@ -1,6 +1,7 @@
 package dynamicfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -8,8 +9,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/errorfs/error_fs.go
+++ b/samples/errorfs/error_fs.go
@@ -15,13 +15,12 @@
 package errorfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
 	"sync"
 	"syscall"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"

--- a/samples/flushfs/flush_fs.go
+++ b/samples/flushfs/flush_fs.go
@@ -15,11 +15,10 @@
 package flushfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/forgetfs/forget_fs.go
+++ b/samples/forgetfs/forget_fs.go
@@ -15,10 +15,9 @@
 package forgetfs
 
 import (
+	"context"
 	"fmt"
 	"os"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/hellofs/hello_fs.go
+++ b/samples/hellofs/hello_fs.go
@@ -15,11 +15,10 @@
 package hellofs
 
 import (
+	"context"
 	"io"
 	"os"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/in_process.go
+++ b/samples/in_process.go
@@ -15,6 +15,7 @@
 package samples
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,7 +26,6 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 // A struct that implements common behavior needed by tests in the samples/

--- a/samples/interruptfs/interrupt_fs.go
+++ b/samples/interruptfs/interrupt_fs.go
@@ -15,11 +15,10 @@
 package interruptfs
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/memfs/memfs.go
+++ b/samples/memfs/memfs.go
@@ -15,13 +15,12 @@
 package memfs
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"syscall"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/memfs/posix_test.go
+++ b/samples/memfs/posix_test.go
@@ -18,14 +18,13 @@
 package memfs_test
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse/fusetesting"
 	. "github.com/jacobsa/oglematchers"

--- a/samples/mount_sample/mount.go
+++ b/samples/mount_sample/mount.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -27,7 +28,6 @@ import (
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/samples/flushfs"
-	"golang.org/x/net/context"
 )
 
 var fType = flag.String("type", "", "The name of the samples/ sub-dir.")

--- a/samples/statfs/statfs.go
+++ b/samples/statfs/statfs.go
@@ -15,10 +15,9 @@
 package statfs
 
 import (
+	"context"
 	"os"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"

--- a/samples/subprocess.go
+++ b/samples/subprocess.go
@@ -16,6 +16,7 @@ package samples
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -27,7 +28,6 @@ import (
 	"sync"
 
 	"github.com/jacobsa/ogletest"
-	"golang.org/x/net/context"
 )
 
 var fToolPath = flag.String(


### PR DESCRIPTION
Go 1.10 should be released this month:
> The go fix tool now replaces imports of "golang.org/x/net/context" with "context". (Forwarding aliases in the former make it completely equivalent to the latter when using Go 1.9 or later.)

This is related to issue https://github.com/jacobsa/fuse/issues/17.