### PR TITLE
Split fuse mount and server launch for flexible use

### DIFF
--- a/internal/buffer/out_message_test.go
+++ b/internal/buffer/out_message_test.go
@@ -280,12 +280,12 @@ func TestOutMessageGrow(t *testing.T) {
 	// Check the resulting length in two ways.
 	const wantLen = payloadSize + OutMessageHeaderSize
 	if got, want := om.Len(), wantLen; got != want {
-		t.Errorf("om.Len() = %d, want %d", got)
+		t.Errorf("om.Len() = %d, want %d", got, want)
 	}
 
 	b := om.Bytes()
 	if got, want := len(b), wantLen; got != want {
-		t.Fatalf("len(om.Len()) = %d, want %d", got)
+		t.Fatalf("len(om.Len()) = %d, want %d", got, want)
 	}
 
 	// Check that the payload was zeroed.

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -165,6 +165,33 @@ func callMount(
 	return
 }
 
+// Check if the given directory is already fuse mounted.
+func isMounted(
+	dir string) (mounted bool, err error) {
+	var stderr bytes.Buffer
+
+	cmd := exec.Command(
+		"mount", "|",
+		"grep",
+		fmt.Sprintf(" %s .* osxfuse ", dir),
+	)
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	if err != nil {
+		mounted = false
+		switch err.(type) {
+		case *exec.ExitError:
+			err = fmt.Errorf("checking if already mounted (osxfuse) : %v\n\nstderr:\n%s", err, stderr.Bytes())
+		default:
+			err = nil
+		}
+	} else {
+		mounted = true
+	}
+	return
+}
+
 // Begin the process of mounting at the given directory, returning a connection
 // to the kernel. Mounting continues in the background, and is complete when an
 // error is written to the supplied channel. The file system may need to

--- a/mount_test.go
+++ b/mount_test.go
@@ -40,7 +40,7 @@ func TestSuccessfulMount(t *testing.T) {
 	// Set up a temporary directory.
 	dir, err := ioutil.TempDir("", "mount_test")
 	if err != nil {
-		t.Fatal("ioutil.TempDir: %v", err)
+		t.Fatalf("ioutil.TempDir: %v", err)
 	}
 
 	defer os.RemoveAll(dir)
@@ -80,7 +80,7 @@ func TestNonEmptyMountPoint(t *testing.T) {
 	// Set up a temporary directory.
 	dir, err := ioutil.TempDir("", "mount_test")
 	if err != nil {
-		t.Fatal("ioutil.TempDir: %v", err)
+		t.Fatalf("ioutil.TempDir: %v", err)
 	}
 
 	defer os.RemoveAll(dir)
@@ -116,7 +116,7 @@ func TestNonexistentMountPoint(t *testing.T) {
 	// Set up a temporary directory.
 	dir, err := ioutil.TempDir("", "mount_test")
 	if err != nil {
-		t.Fatal("ioutil.TempDir: %v", err)
+		t.Fatalf("ioutil.TempDir: %v", err)
 	}
 
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
When we want a file system to work well with automounting, we may want more flexibility in `fuse.Mount`, i.e. mounting fuse file system in the original process and serving requests in daemonized process(es).
This patch does it in a completely backward-compatible way.

For reference, based on this patch, I cooked up a patch to make `kahing/goofys.git` work well with automounting. (https://github.com/kahing/goofys/pull/369)

Please review, thanks.