### PR TITLE
convertAttributes: set S_ISUD bit from os.FileMode’s os.ModeSetuid

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -856,6 +856,9 @@ func convertAttributes(
 	case in.Mode&os.ModeSocket != 0:
 		out.Mode |= syscall.S_IFSOCK
 	}
+	if in.Mode&os.ModeSetuid != 0 {
+		out.Mode |= syscall.S_ISUID
+	}
 }
 
 // Convert an absolute cache expiration time to a relative time from now for


### PR DESCRIPTION
Before this change, the package effectively silently stripped the suid bit.