### PR TITLE
Don't log ERANGE for ListXattrOp.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -432,7 +432,10 @@ func (c *Connection) shouldLogError(
 		if err == syscall.ENOENT {
 			return false
 		}
-
+	case *fuseops.ListXattrOp:
+		if err == syscall.ENODATA || err == syscall.ERANGE {
+			return false
+		}
 	case *fuseops.GetXattrOp:
 		if err == syscall.ENODATA || err == syscall.ERANGE {
 			return false


### PR DESCRIPTION
ListXattrOp behaves similarly to GetXattrOp in that you have to return ERANGE in order to indicate the size of the attribute list, so logging errors isn't warranted.