### PR TITLE
fix getxattr and listxattr

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -603,17 +603,6 @@ func (c *Connection) kernelResponse(
 	if opErr != nil {
 		handled := false
 
-		if opErr == syscall.ERANGE {
-			switch o := op.(type) {
-			case *fuseops.GetXattrOp:
-				writeXattrSize(m, uint32(o.BytesRead))
-				handled = true
-			case *fuseops.ListXattrOp:
-				writeXattrSize(m, uint32(o.BytesRead))
-				handled = true
-			}
-		}
-
 		if !handled {
 			m.OutHeader().Error = -int32(syscall.EIO)
 			if errno, ok := opErr.(syscall.Errno); ok {
@@ -792,14 +781,14 @@ func (c *Connection) kernelResponseForOp(
 		// convertInMessage already set up the destination buffer to be at the end
 		// of the out message. We need only shrink to the right size based on how
 		// much the user read.
-		if o.BytesRead == 0 {
+		if len(o.Dst) == 0 {
 			writeXattrSize(m, uint32(o.BytesRead))
 		} else {
 			m.ShrinkTo(buffer.OutMessageHeaderSize + o.BytesRead)
 		}
 
 	case *fuseops.ListXattrOp:
-		if o.BytesRead == 0 {
+		if len(o.Dst) == 0 {
 			writeXattrSize(m, uint32(o.BytesRead))
 		} else {
 			m.ShrinkTo(buffer.OutMessageHeaderSize + o.BytesRead)

--- a/samples/memfs/memfs.go
+++ b/samples/memfs/memfs.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
 	"github.com/jacobsa/syncutil"
+	"golang.org/x/sys/unix"
 )
 
 type memFS struct {
@@ -735,11 +736,11 @@ func (fs *memFS) SetXattr(ctx context.Context,
 	_, ok := inode.xattrs[op.Name]
 
 	switch op.Flags {
-	case 0x1:
+	case unix.XATTR_CREATE:
 		if ok {
 			err = fuse.EEXIST
 		}
-	case 0x2:
+	case unix.XATTR_REPLACE:
 		if !ok {
 			err = fuse.ENOATTR
 		}

--- a/samples/memfs/memfs.go
+++ b/samples/memfs/memfs.go
@@ -679,7 +679,7 @@ func (fs *memFS) GetXattr(ctx context.Context,
 		op.BytesRead = len(value)
 		if len(op.Dst) >= len(value) {
 			copy(op.Dst, value)
-		} else {
+		} else if len(op.Dst) != 0 {
 			err = syscall.ERANGE
 		}
 	} else {
@@ -703,8 +703,8 @@ func (fs *memFS) ListXattr(ctx context.Context,
 		if err == nil && len(dst) >= keyLen {
 			copy(dst, key)
 			dst = dst[keyLen:]
-		} else {
-			err = syscall.ERANGE
+		} else if len(op.Dst) != 0 {
+			return syscall.ERANGE
 		}
 		op.BytesRead += keyLen
 	}


### PR DESCRIPTION
previously, this will fail if /mnt/file doesn't have an xattr:

```
listxattr("/mnt/file", 0x7fe8b3686830, 256) = -1 EIO (Input/output error)
```

We should be returning the actual size only if the input size is
zero. Related issue is if the filesystem returns ERANGE, we should
propagate that error instead of returning the actual size.

Replaced go-xattr usage with x/sys/unix so we can test this.