### PR TITLE
make fstype be composed of "fuse" and subtype

### DIFF
--- a/mount_linux.go
+++ b/mount_linux.go
@@ -149,11 +149,16 @@ func directmount(dir string, cfg *MountConfig) (*os.File, error) {
 		delete(opts, k)
 	}
 	delete(opts, "fsname") // handled via fstype mount(2) parameter
+	fstype := "fuse"
+	if subtype, ok := opts["subtype"]; ok {
+		fstype += "." + subtype
+	}
+	delete(opts, "subtype")
 	data += "," + mapToOptionsString(opts)
 	if err := unix.Mount(
 		cfg.FSName, // source
 		dir,        // target
-		"fuse",     // fstype
+		fstype,     // fstype
 		mountflag,  // mountflag
 		data,       // data
 	); err != nil {


### PR DESCRIPTION
fix #76

i  recompile fusermount and print the mount args, got:

> source(polefs-wy3),target(/home/wangyang5/polefs/mnt),**fstype(fuse.polefs)**,mflags(6),data(default_permissions,allow_other,fd=4,rootmode=40000,user_id=0,group_id=0)

the err args is:

>source(polefs-wy3),target(/home/wangyang5/polefs/mnt),**fstype(fuse)**,mflags(6),data(default_permissions,allow_other,fd=4,rootmode=40000,user_id=0,group_id=0,**subtype=polefs**)

find that subtype is not in the data, it's part of fstype!

after remove subtype from data, and put it in fstype, it's mount ok with root user

@stapelberg please review
