### PR TITLE
rw and ro were flipped

### DIFF
--- a/mount_linux.go
+++ b/mount_linux.go
@@ -108,8 +108,8 @@ func disableFunc(flag uintptr) func(uintptr) uintptr {
 
 // As per libfuse/fusermount.c:602: https://bit.ly/2SgtWYM#L602
 var mountflagopts = map[string]func(uintptr) uintptr{
-	"rw":      enableFunc(unix.MS_RDONLY),
-	"ro":      disableFunc(unix.MS_RDONLY),
+	"rw":      disableFunc(unix.MS_RDONLY),
+	"ro":      enableFunc(unix.MS_RDONLY),
 	"suid":    disableFunc(unix.MS_NOSUID),
 	"nosuid":  enableFunc(unix.MS_NOSUID),
 	"dev":     disableFunc(unix.MS_NODEV),


### PR DESCRIPTION
when user mount via fstab, we get '-o rw' implicitly, and under
directmount this _enabled_ MS_RDONLY, which is the opposite of what we
want

refs https://github.com/kahing/goofys/issues/483