### PR TITLE
Set max file/folder name length.

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -706,6 +706,7 @@ func (c *Connection) kernelResponseForOp(
 		out.St.Bavail = o.BlocksAvailable
 		out.St.Files = o.Inodes
 		out.St.Ffree = o.InodesFree
+		out.St.Namelen = 255
 
 		// The posix spec for sys/statvfs.h (http://goo.gl/LktgrF) defines the
 		// following fields of statvfs, among others:


### PR DESCRIPTION
Currently, trying to create a file/folder with a name longer than 1 character fails. This fixes that by setting the max name length in StatFS.