### PR TITLE
Add support for max_pages and increase to 256

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -161,6 +161,9 @@ func (c *Connection) Init() error {
 
 	// Tell the kernel not to use pitifully small 4 KiB writes.
 	initOp.Flags |= fusekernel.InitBigWrites
+	// kernel 4.20 increases the max from 32 -> 256
+	initOp.Flags |= fusekernel.InitMaxPages
+	initOp.MaxPages = 256
 
 	// Enable writeback caching if the user hasn't asked us not to.
 	if !c.cfg.DisableWritebackCaching {

--- a/conversions.go
+++ b/conversions.go
@@ -796,7 +796,12 @@ func (c *Connection) kernelResponseForOp(
 		out.Minor = o.Library.Minor
 		out.MaxReadahead = o.MaxReadahead
 		out.Flags = uint32(o.Flags)
+		// Default values
+		out.MaxBackground = 1000
+		out.CongestionThreshold = 750
 		out.MaxWrite = o.MaxWrite
+		out.TimeGran = 1
+		out.MaxPages = o.MaxPages
 
 	default:
 		panic(fmt.Sprintf("Unexpected op: %#v", op))

--- a/conversions.go
+++ b/conversions.go
@@ -797,8 +797,8 @@ func (c *Connection) kernelResponseForOp(
 		out.MaxReadahead = o.MaxReadahead
 		out.Flags = uint32(o.Flags)
 		// Default values
-		out.MaxBackground = 1000
-		out.CongestionThreshold = 750
+		out.MaxBackground = 12
+		out.CongestionThreshold = 9
 		out.MaxWrite = o.MaxWrite
 		out.TimeGran = 1
 		out.MaxPages = o.MaxPages

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,0 @@
-module github.com/jacobsa/fuse

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/jacobsa/fuse

--- a/internal/buffer/in_message_linux.go
+++ b/internal/buffer/in_message_linux.go
@@ -16,6 +16,5 @@ package buffer
 
 // The maximum fuse write request size that InMessage can acommodate.
 //
-// Experimentally, Linux appears to refuse to honor a MaxWrite setting in an
-// INIT response of more than 128 KiB.
-const MaxWriteSize = 1 << 17
+// As of kernel 4.20 Linux accepts writes up to 256 pages or 1MiB
+const MaxWriteSize = 1 << 20

--- a/internal/buffer/out_message_linux.go
+++ b/internal/buffer/out_message_linux.go
@@ -17,5 +17,5 @@ package buffer
 // The maximum read size that we expect to ever see from the kernel, used for
 // calculating the size of out messages.
 //
-// For 4 KiB pages, this is 1024 KiB (cf. https://goo.gl/HOiEYo)
+// For 4 KiB pages, this is 1024 KiB (cf. https://github.com/torvalds/linux/blob/15db16837a35d8007cb8563358787412213db25e/fs/fuse/fuse_i.h#L38-L40)
 const MaxReadSize = 1 << 20

--- a/internal/buffer/out_message_linux.go
+++ b/internal/buffer/out_message_linux.go
@@ -17,5 +17,5 @@ package buffer
 // The maximum read size that we expect to ever see from the kernel, used for
 // calculating the size of out messages.
 //
-// For 4 KiB pages, this is 128 KiB (cf. https://goo.gl/HOiEYo)
-const MaxReadSize = 1 << 17
+// For 4 KiB pages, this is 1024 KiB (cf. https://goo.gl/HOiEYo)
+const MaxReadSize = 1 << 20

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -725,7 +725,8 @@ type InitOut struct {
 	MaxWrite            uint32
 	TimeGran            uint32
 	MaxPages            uint16
-	Unused              [8]uint16
+	MapAlignment        uint16
+	Unused              [8]uint32
 }
 
 type InterruptIn struct {

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -44,7 +44,7 @@ import (
 // The FUSE version implemented by the package.
 const (
 	ProtoVersionMinMajor = 7
-	ProtoVersionMinMinor = 28
+	ProtoVersionMinMinor = 19
 	ProtoVersionMaxMajor = 7
 	ProtoVersionMaxMinor = 31
 )

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -724,7 +724,8 @@ type InitOut struct {
 	CongestionThreshold uint16
 	MaxWrite            uint32
 	TimeGran            uint32
-	MaxPages            uint32
+	MaxPages            uint16
+	Unused              [8]uint16
 }
 
 type InterruptIn struct {

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -44,9 +44,9 @@ import (
 // The FUSE version implemented by the package.
 const (
 	ProtoVersionMinMajor = 7
-	ProtoVersionMinMinor = 8
+	ProtoVersionMinMinor = 28
 	ProtoVersionMaxMajor = 7
-	ProtoVersionMaxMinor = 12
+	ProtoVersionMaxMinor = 31
 )
 
 const (
@@ -266,6 +266,7 @@ const (
 	InitAsyncDIO         InitFlags = 1 << 15
 	InitWritebackCache   InitFlags = 1 << 16
 	InitNoOpenSupport    InitFlags = 1 << 17
+	InitMaxPages         InitFlags = 1 << 22
 	InitCacheSymlinks    InitFlags = 1 << 23
 	InitNoOpendirSupport InitFlags = 1 << 24
 
@@ -286,6 +287,7 @@ var initFlagNames = []flagName{
 	{uint32(InitAtomicTrunc), "InitAtomicTrunc"},
 	{uint32(InitExportSupport), "InitExportSupport"},
 	{uint32(InitBigWrites), "InitBigWrites"},
+	{uint32(InitMaxPages), "InitMaxPages"},
 	{uint32(InitDontMask), "InitDontMask"},
 	{uint32(InitSpliceWrite), "InitSpliceWrite"},
 	{uint32(InitSpliceMove), "InitSpliceMove"},
@@ -714,12 +716,15 @@ type InitIn struct {
 const InitInSize = int(unsafe.Sizeof(InitIn{}))
 
 type InitOut struct {
-	Major        uint32
-	Minor        uint32
-	MaxReadahead uint32
-	Flags        uint32
-	Unused       uint32
-	MaxWrite     uint32
+	Major               uint32
+	Minor               uint32
+	MaxReadahead        uint32
+	Flags               uint32
+	MaxBackground       uint16
+	CongestionThreshold uint16
+	MaxWrite            uint32
+	TimeGran            uint32
+	MaxPages            uint32
 }
 
 type InterruptIn struct {

--- a/ops.go
+++ b/ops.go
@@ -44,5 +44,5 @@ type initOp struct {
 	MaxReadahead  uint32
 	MaxBackground uint16
 	MaxWrite      uint32
-	MaxPages      uint32
+	MaxPages      uint16
 }

--- a/ops.go
+++ b/ops.go
@@ -40,7 +40,9 @@ type initOp struct {
 	Flags fusekernel.InitFlags
 
 	// Out
-	Library      fusekernel.Protocol
-	MaxReadahead uint32
-	MaxWrite     uint32
+	Library       fusekernel.Protocol
+	MaxReadahead  uint32
+	MaxBackground uint16
+	MaxWrite      uint32
+	MaxPages      uint32
 }

--- a/samples/statfs/statfs_test.go
+++ b/samples/statfs/statfs_test.go
@@ -194,7 +194,7 @@ func (t *StatFSTest) WriteSize() {
 	// small chunks of data.
 	switch runtime.GOOS {
 	case "linux":
-		ExpectEq(1<<17, t.fs.MostRecentWriteSize())
+		ExpectEq(1<<20, t.fs.MostRecentWriteSize())
 
 	case "darwin":
 		ExpectEq(1<<20, t.fs.MostRecentWriteSize())


### PR DESCRIPTION
This PR lacks many things, but is a start to add support for `max_pages`, which was added in kernel 4.20, fuse version 7.28.

Default values for the new fields in `init_out` were taken from where I think the kernel sets their default values. 
https://github.com/torvalds/linux/blob/9f67672a817ec046f7554a885f0fe0d60e1bf99f/include/uapi/linux/fuse.h#L740-L752 

`max_background` https://github.com/torvalds/linux/blob/27787ba3fa4904422b3928b898d1bd3d74d98bea/fs/fuse/inode.c#L58
`congestion_threshold` https://github.com/torvalds/linux/blob/27787ba3fa4904422b3928b898d1bd3d74d98bea/fs/fuse/inode.c#L61
`time_gran` https://github.com/torvalds/linux/blob/27787ba3fa4904422b3928b898d1bd3d74d98bea/fs/fuse/inode.c#L1263