### PR TITLE
Add configuration to control async reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 
 # Folders
+.idea/
 _obj
 _test
 

--- a/connection.go
+++ b/connection.go
@@ -162,7 +162,7 @@ func (c *Connection) Init() error {
 	// Tell the kernel not to use pitifully small 4 KiB writes.
 	initOp.Flags |= fusekernel.InitBigWrites
 
-	if !c.cfg.DisableAsyncReads {
+	if c.cfg.EnableAsyncReads {
 		initOp.Flags |= fusekernel.InitAsyncRead
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -161,6 +161,11 @@ func (c *Connection) Init() error {
 
 	// Tell the kernel not to use pitifully small 4 KiB writes.
 	initOp.Flags |= fusekernel.InitBigWrites
+
+	if !c.cfg.DisableAsyncReads {
+		initOp.Flags |= fusekernel.InitAsyncRead
+	}
+
 	// kernel 4.20 increases the max from 32 -> 256
 	initOp.Flags |= fusekernel.InitMaxPages
 	initOp.MaxPages = 256

--- a/mount_config.go
+++ b/mount_config.go
@@ -174,6 +174,10 @@ type MountConfig struct {
 	// /proc/mounts will show the filesystem type as fuse.<Subtype>.
 	// If not set, /proc/mounts will show the filesystem type as fuse/fuseblk.
 	Subtype string
+
+	//Flag to disable async reads that are received from
+	//the kernel
+	DisableAsyncReads bool
 }
 
 // Create a map containing all of the key=value mount options to be given to

--- a/mount_config.go
+++ b/mount_config.go
@@ -177,7 +177,7 @@ type MountConfig struct {
 
 	//Flag to disable async reads that are received from
 	//the kernel
-	DisableAsyncReads bool
+	EnableAsyncReads bool
 }
 
 // Create a map containing all of the key=value mount options to be given to

--- a/mount_config.go
+++ b/mount_config.go
@@ -175,8 +175,8 @@ type MountConfig struct {
 	// If not set, /proc/mounts will show the filesystem type as fuse/fuseblk.
 	Subtype string
 
-	//Flag to disable async reads that are received from
-	//the kernel
+	// Flag to enable async reads that are received from
+	// the kernel
 	EnableAsyncReads bool
 }
 


### PR DESCRIPTION
In current jacobsa async reads is disabled for all users and nobody can switch it on if necessary. In this PR, I have created a configurable option in MountConfig to allow the user to control this feature

