### PR TITLE
InMessage is initialized with a storage allocated before reads

### DIFF
--- a/freelists.go
+++ b/freelists.go
@@ -31,7 +31,7 @@ func (c *Connection) getInMessage() *buffer.InMessage {
 	c.mu.Unlock()
 
 	if x == nil {
-		x = new(buffer.InMessage)
+		x = buffer.NewInMessage()
 	}
 
 	return x

--- a/internal/buffer/in_message.go
+++ b/internal/buffer/in_message.go
@@ -44,11 +44,17 @@ type InMessage struct {
 	storage   []byte
 }
 
+// NewInMessage creates a new InMessage with its storage initialized.
+func NewInMessage() *InMessage {
+	return &InMessage{
+		storage: make([]byte, bufSize),
+	}
+}
+
 // Initialize with the data read by a single call to r.Read. The first call to
 // Consume will consume the bytes directly after the fusekernel.InHeader
 // struct.
 func (m *InMessage) Init(r io.Reader) error {
-	m.storage = make([]byte, bufSize, bufSize)
 	n, err := r.Read(m.storage[:])
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #109. In #102, the storage of the InMessage gets allocated every
time it's being read, which is expensive and caused issues like
https://github.com/GoogleCloudPlatform/gcsfuse/issues/563. So, this
change moves the allocation to its own function, called only once when
the struct is initialized before the reads.

Tested with https://github.com/GoogleCloudPlatform/gcsfuse.