### PR TITLE
Disable go test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,9 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y fuse3 libfuse-dev
     - name: Build
       run: go build ./...
-    # Exclude TestPosix and TestMemFS because some of the tests hung indefinitely.
-    # Also, tests need to be run sequentially to avoid hanging indefinitely.
-    - name: Run tests
-      run: go test -v -p 1 -bench=. -run="TestSuccessfulMount|TestNonexistentMountPoint|TestCachingFS|TestDynamicFS|TestErrorFS|TestFlushFS|TestForgetFS|TestHelloFS|TestInterruptFS|TestReadonlyLoopbackFS|TestStatFS" ./...
+    # Disabled running `go test` because running tests hung at random,
+    # preventing us from running the tests in CI reliably.
+    # (cf. https://github.com/jacobsa/fuse/issues/97)
 
   macos-build:
     runs-on: macos-latest


### PR DESCRIPTION
This disables running `go test` in CI as we cannot reliably run tests.
This is a follow-up PR of #111.