### PR TITLE
Add a CI step to run go vet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,19 @@ on:
       - '*'
 
 jobs:
+  go-vet:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2.1.4
+      with:
+        go-version: 1.16
+      id: go
+    - name: Run go vet
+      run: go vet ./...
+
   linux-tests:
     runs-on: ubuntu-20.04
 

--- a/connection.go
+++ b/connection.go
@@ -129,8 +129,8 @@ func (c *Connection) Init() error {
 
 	// Make sure the protocol version spoken by the kernel is new enough.
 	min := fusekernel.Protocol{
-		fusekernel.ProtoVersionMinMajor,
-		fusekernel.ProtoVersionMinMinor,
+		Major: fusekernel.ProtoVersionMinMajor,
+		Minor: fusekernel.ProtoVersionMinMinor,
 	}
 
 	if initOp.Kernel.LT(min) {
@@ -140,8 +140,8 @@ func (c *Connection) Init() error {
 
 	// Downgrade our protocol if necessary.
 	c.protocol = fusekernel.Protocol{
-		fusekernel.ProtoVersionMaxMajor,
-		fusekernel.ProtoVersionMaxMinor,
+		Major: fusekernel.ProtoVersionMaxMajor,
+		Minor: fusekernel.ProtoVersionMaxMinor,
 	}
 
 	if initOp.Kernel.LT(c.protocol) {

--- a/conversions.go
+++ b/conversions.go
@@ -412,7 +412,7 @@ func convertInMessage(
 		}
 
 		o = &initOp{
-			Kernel:       fusekernel.Protocol{in.Major, in.Minor},
+			Kernel:       fusekernel.Protocol{Major: in.Major, Minor: in.Minor},
 			MaxReadahead: in.MaxReadahead,
 			Flags:        fusekernel.InitFlags(in.Flags),
 		}

--- a/internal/buffer/out_message.go
+++ b/internal/buffer/out_message.go
@@ -146,5 +146,5 @@ func (m *OutMessage) Bytes() []byte {
 		Cap:  l,
 	}
 
-	return *(*[]byte)(unsafe.Pointer(&sh))
+	return *(*[]byte)(unsafe.Pointer(&sh.Data))
 }

--- a/internal/buffer/out_message_test.go
+++ b/internal/buffer/out_message_test.go
@@ -20,7 +20,7 @@ func toByteSlice(p unsafe.Pointer, n int) []byte {
 		Cap:  n,
 	}
 
-	return *(*[]byte)(unsafe.Pointer(&sh))
+	return *(*[]byte)(unsafe.Pointer(&sh.Data))
 }
 
 // fillWithGarbage writes random data to [p, p+n).


### PR DESCRIPTION
This adds a CI step to run `go vet` command which runs static analysis ([available checks](https://pkg.go.dev/cmd/vet)).