### PR TITLE
refactor: Remove duplicate code in test

### DIFF
--- a/samples/memfs/memfs_test.go
+++ b/samples/memfs/memfs_test.go
@@ -855,10 +855,6 @@ func (t *MemFSTest) AppendMode() {
 	AssertEq(nil, err)
 	ExpectEq(13, off)
 
-	off, err = getFileOffset(f)
-	AssertEq(nil, err)
-	ExpectEq(13, off)
-
 	// Read back the contents of the file, which should be correct even though we
 	// seeked to a silly place before writing the world part.
 	//


### PR DESCRIPTION
I found a snipped of duplicate code in a test and removed it. The original copy is located right above. 

The unchanged code with the duplicate looks like this: 
```
// The offset should have been updated to point at the end of the file.
off, err = getFileOffset(f)
AssertEq(nil, err)
ExpectEq(13, off)

off, err = getFileOffset(f)
AssertEq(nil, err)
ExpectEq(13, off)
```
