### PR TITLE
Add support for the FUSE_BATCH_FORGET operation

### DIFF
--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -220,6 +220,32 @@ type ForgetInodeOp struct {
 	OpContext OpContext
 }
 
+// BatchForgetEntry represents one Inode entry to forget in the BatchForgetOp.
+//
+// Everything written in the ForgetInodeOp docs applies for the BatchForgetEntry
+// too.
+type BatchForgetEntry struct {
+	// The inode whose reference count should be decremented.
+	Inode InodeID
+
+	// The amount to decrement the reference count.
+	N uint64
+}
+
+// Decrement the reference counts for a list of inode IDs previously issued by the file
+// system.
+//
+// This operation is a batch of ForgetInodeOp operations. Every entry in
+// Entries is one ForgetInodeOp operation. See the docs of ForgetInodeOp
+// for further details.
+type BatchForgetOp struct {
+	// Entries is a list of Forget operations. One could treat every entry in the
+	// list as a single ForgetInodeOp operation.
+	Entries []BatchForgetEntry
+
+	OpContext OpContext
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Inode creation
 ////////////////////////////////////////////////////////////////////////

--- a/fuseutil/file_system.go
+++ b/fuseutil/file_system.go
@@ -39,6 +39,7 @@ type FileSystem interface {
 	GetInodeAttributes(context.Context, *fuseops.GetInodeAttributesOp) error
 	SetInodeAttributes(context.Context, *fuseops.SetInodeAttributesOp) error
 	ForgetInode(context.Context, *fuseops.ForgetInodeOp) error
+	BatchForget(context.Context, *fuseops.BatchForgetOp) error
 	MkDir(context.Context, *fuseops.MkDirOp) error
 	MkNode(context.Context, *fuseops.MkNodeOp) error
 	CreateFile(context.Context, *fuseops.CreateFileOp) error
@@ -150,6 +151,9 @@ func (s *fileSystemServer) handleOp(
 
 	case *fuseops.ForgetInodeOp:
 		err = s.fs.ForgetInode(ctx, typed)
+
+	case *fuseops.BatchForgetOp:
+		err = s.fs.BatchForget(ctx, typed)
 
 	case *fuseops.MkDirOp:
 		err = s.fs.MkDir(ctx, typed)

--- a/fuseutil/not_implemented_file_system.go
+++ b/fuseutil/not_implemented_file_system.go
@@ -60,6 +60,12 @@ func (fs *NotImplementedFileSystem) ForgetInode(
 	return fuse.ENOSYS
 }
 
+func (fs *NotImplementedFileSystem) BatchForget(
+	ctx context.Context,
+	op *fuseops.BatchForgetOp) error {
+	return fuse.ENOSYS
+}
+
 func (fs *NotImplementedFileSystem) MkDir(
 	ctx context.Context,
 	op *fuseops.MkDirOp) error {

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -386,6 +386,7 @@ const (
 	OpDestroy     = 38
 	OpIoctl       = 39 // Linux?
 	OpPoll        = 40 // Linux?
+	OpBatchForget = 42
 	OpFallocate   = 43
 
 	// OS X
@@ -414,6 +415,16 @@ func EntryOutSize(p Protocol) uintptr {
 }
 
 type ForgetIn struct {
+	Nlookup uint64
+}
+
+type BatchForgetCountIn struct {
+	Count uint32
+	dummy uint32
+}
+
+type BatchForgetEntryIn struct {
+	Inode   int64
 	Nlookup uint64
 }
 


### PR DESCRIPTION
There are certain Kernel versions which do not send individual
Forget operations after they receive "not implemented" for Batch Forget.
One example is "5.4.0-110-generic" on Ubuntu 20.04. I am sure there are
plenty of others.

This leads to inode "leaks". Where reference counts are never decreased
and the inodes were left hanging around long after they are not needed
any more.

The best way to fix that was adding support for batch operations to the
lib. This way all users will be able to benefit from the batching
optimization.