### PR TITLE
Support unprivileged mounts on Linux

### DIFF
--- a/mount_linux_test.go
+++ b/mount_linux_test.go
@@ -1,0 +1,37 @@
+package fuse
+
+import (
+	"testing"
+)
+
+func Test_parseFuseFd(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		fd, err := parseFuseFd("/dev/fd/42")
+		if fd != 42 {
+			t.Errorf("expected 42, got %d", fd)
+		}
+		if err != nil {
+			t.Errorf("expected no error, got %#v", err)
+		}
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		fd, err := parseFuseFd("/dev/fd/-42")
+		if fd != -1 {
+			t.Errorf("expected an invalid fd, got %d", fd)
+		}
+		if err == nil {
+			t.Errorf("expected an error, nil")
+		}
+	})
+
+	t.Run("not an int", func(t *testing.T) {
+		fd, err := parseFuseFd("/dev/fd/3.14159")
+		if fd != -1 {
+			t.Errorf("expected an invalid fd, got %d", fd)
+		}
+		if err == nil {
+			t.Errorf("expected an error, nil")
+		}
+	})
+}


### PR DESCRIPTION
Adds support for unprivileged mounts by allowing a parent process to pass an open `/dev/fuse` file descriptor as a mount point. Follows [the libfuse3 format](https://github.com/libfuse/libfuse/blob/a56147d3cb269d64635408ab5588ad66eba43943/ChangeLog.rst#libfuse-330-2018-11-06) and uses `/dev/fd/N` to represent an open fd.

I added a quick test for parsing `/dev/fd/N` fds. The `memfs` tests on master seem to hang and fail pretty consistently on my system.