### PR TITLE
Add more debugging logs to the mounting process so we get more visibility for customer issues

### DIFF
--- a/mount.go
+++ b/mount.go
@@ -53,10 +53,16 @@ func Mount(
 	}
 
 	// Begin the mounting process, which will continue in the background.
+	if config.DebugLogger != nil {
+		config.DebugLogger.Println("Beginning the mounting process")
+	}
 	ready := make(chan error, 1)
 	dev, err := mount(dir, config, ready)
 	if err != nil {
 		return nil, fmt.Errorf("mount: %v", err)
+	}
+	if config.DebugLogger != nil {
+		config.DebugLogger.Println("Completed the mounting process")
 	}
 
 	// Choose a parent context for ops.
@@ -65,6 +71,9 @@ func Mount(
 		cfgCopy.OpContext = context.Background()
 	}
 
+	if config.DebugLogger != nil {
+		config.DebugLogger.Println("Creating a connection object")
+	}
 	// Create a Connection object wrapping the device.
 	connection, err := newConnection(
 		cfgCopy,
@@ -74,6 +83,9 @@ func Mount(
 	if err != nil {
 		return nil, fmt.Errorf("newConnection: %v", err)
 	}
+	if config.DebugLogger != nil {
+		config.DebugLogger.Println("Successfully created the connection")
+	}
 
 	// Serve the connection in the background. When done, set the join status.
 	go func() {
@@ -81,6 +93,10 @@ func Mount(
 		mfs.joinStatus = connection.close()
 		close(mfs.joinStatusAvailable)
 	}()
+
+	if config.DebugLogger != nil {
+		config.DebugLogger.Println("Waiting for mounting process to complete")
+	}
 
 	// Wait for the mount process to complete.
 	if err := <-ready; err != nil {

--- a/mount.go
+++ b/mount.go
@@ -127,12 +127,7 @@ func checkMountPoint(dir string) error {
 	return nil
 }
 
-func fusermount(
-	binary string,
-	argv []string,
-	additionalEnv []string,
-	wait bool,
-	debugLogger *log.Logger) (*os.File, error) {
+func fusermount(binary string, argv []string, additionalEnv []string, wait bool, debugLogger *log.Logger) (*os.File, error) {
 	if debugLogger != nil {
 		debugLogger.Println("Creating a socket pair")
 	}

--- a/mount_darwin.go
+++ b/mount_darwin.go
@@ -205,7 +205,7 @@ func callMountCommFD(
 	env = append(env, "_FUSE_COMMVERS=2")
 	argv = append(argv, dir)
 
-	return fusermount(bin, argv, env, false)
+	return fusermount(bin, argv, env, false, cfg.DebugLogger)
 }
 
 // Begin the process of mounting at the given directory, returning a connection

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -55,6 +55,9 @@ var mountflagopts = map[string]func(uintptr) uintptr{
 var errFallback = errors.New("sentinel: fallback to fusermount(1)")
 
 func directmount(dir string, cfg *MountConfig) (*os.File, error) {
+	if cfg.DebugLogger != nil {
+		cfg.DebugLogger.Println("Preparing for direct mounting")
+	}
 	// We use syscall.Open + os.NewFile instead of os.OpenFile so that the file
 	// is opened in blocking mode. When opened in non-blocking mode, the Go
 	// runtime tries to use poll(2), which does not work with /dev/fuse.
@@ -63,6 +66,10 @@ func directmount(dir string, cfg *MountConfig) (*os.File, error) {
 		return nil, errFallback
 	}
 	dev := os.NewFile(uintptr(fd), "/dev/fuse")
+
+	if cfg.DebugLogger != nil {
+		cfg.DebugLogger.Println("Successfully opened the /dev/fuse in blocking mode")
+	}
 	// As per libfuse/fusermount.c:847: https://bit.ly/2SgtWYM#L847
 	data := fmt.Sprintf("fd=%d,rootmode=40000,user_id=%d,group_id=%d",
 		dev.Fd(), os.Getuid(), os.Getgid())
@@ -84,6 +91,10 @@ func directmount(dir string, cfg *MountConfig) (*os.File, error) {
 	}
 	delete(opts, "subtype")
 	data += "," + mapToOptionsString(opts)
+
+	if cfg.DebugLogger != nil {
+		cfg.DebugLogger.Println("Starting the unix mounting")
+	}
 	if err := unix.Mount(
 		cfg.FSName, // source
 		dir,        // target
@@ -108,6 +119,9 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 	// On linux, mounting is never delayed.
 	ready <- nil
 
+	if cfg.DebugLogger != nil {
+		cfg.DebugLogger.Println("Parsing fuse file descriptor")
+	}
 	// If the mountpoint is /dev/fd/N, assume that the file descriptor N is an
 	// already open FUSE channel. Parse it, cast it to an fd, and don't do any
 	// other part of the mount dance.

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -108,6 +108,9 @@ func directmount(dir string, cfg *MountConfig) (*os.File, error) {
 		}
 		return nil, err
 	}
+	if cfg.DebugLogger != nil {
+		cfg.DebugLogger.Println("Unix mounting completed successfully")
+	}
 	return dev, nil
 }
 
@@ -134,6 +137,9 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 	// have the CAP_SYS_ADMIN capability.
 	dev, err := directmount(dir, cfg)
 	if err == errFallback {
+		if cfg.DebugLogger != nil {
+			cfg.DebugLogger.Println("Directmount failed. Trying fallback.")
+		}
 		fusermountPath, err := findFusermount()
 		if err != nil {
 			return nil, err
@@ -143,7 +149,7 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 			"--",
 			dir,
 		}
-		return fusermount(fusermountPath, argv, []string{}, true)
+		return fusermount(fusermountPath, argv, []string{}, true, cfg.DebugLogger)
 	}
 	return dev, err
 }

--- a/samples/mount_sample/mount.go
+++ b/samples/mount_sample/mount.go
@@ -40,7 +40,7 @@ var fFlushError = flag.Int("flushfs.flush_error", 0, "")
 var fFsyncError = flag.Int("flushfs.fsync_error", 0, "")
 
 var fReadOnly = flag.Bool("read_only", false, "Mount in read-only mode.")
-var fDebug = flag.Bool("debug", true, "Enable debug logging.")
+var fDebug = flag.Bool("debug", false, "Enable debug logging.")
 
 func makeFlushFS() (fuse.Server, error) {
 	// Check the flags.

--- a/samples/mount_sample/mount.go
+++ b/samples/mount_sample/mount.go
@@ -40,7 +40,7 @@ var fFlushError = flag.Int("flushfs.flush_error", 0, "")
 var fFsyncError = flag.Int("flushfs.fsync_error", 0, "")
 
 var fReadOnly = flag.Bool("read_only", false, "Mount in read-only mode.")
-var fDebug = flag.Bool("debug", false, "Enable debug logging.")
+var fDebug = flag.Bool("debug", true, "Enable debug logging.")
 
 func makeFlushFS() (fuse.Server, error) {
 	// Check the flags.


### PR DESCRIPTION
Bugs like https://github.com/GoogleCloudPlatform/gcsfuse/issues/670 and https://github.com/GoogleCloudPlatform/gcsfuse/issues/715 are hard to debug because the mounting process is stuck at a very high level log and we are not able to get any more information about the underneath mounting process.
This PR adds some debug logs to the mount process so we can get some visibility into where the mounting gets stuck and help mitigate the issues.