### PR TITLE
Pull request for some Get/Set set-UID/set-GID/stick-bit attributes + UID/GID context of the userland processus invoking syscall

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -919,6 +919,12 @@ func convertAttributes(
 	if in.Mode&os.ModeSetuid != 0 {
 		out.Mode |= syscall.S_ISUID
 	}
+	if in.Mode&os.ModeSetgid != 0 {
+		out.Mode |= syscall.S_ISGID
+	}
+	if in.Mode&os.ModeSticky != 0 {
+		out.Mode |= syscall.S_ISVTX
+	}
 }
 
 // Convert an absolute cache expiration time to a relative time from now for
@@ -974,6 +980,9 @@ func convertFileMode(unixMode uint32) os.FileMode {
 	}
 	if unixMode&syscall.S_ISGID != 0 {
 		mode |= os.ModeSetgid
+	}
+	if unixMode&syscall.S_ISVTX != 0 {
+		mode |= os.ModeSticky
 	}
 	return mode
 }

--- a/conversions.go
+++ b/conversions.go
@@ -76,6 +76,14 @@ func convertInMessage(
 		o = to
 
 		valid := fusekernel.SetattrValid(in.Valid)
+		if valid&fusekernel.SetattrUid != 0 {
+			to.Uid = &in.Uid
+		}
+
+		if valid&fusekernel.SetattrGid != 0 {
+			to.Gid = &in.Gid
+		}
+
 		if valid&fusekernel.SetattrSize != 0 {
 			to.Size = &in.Size
 		}

--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -161,6 +161,8 @@ type SetInodeAttributesOp struct {
 	Handle *HandleID
 
 	// The attributes to modify, or nil for attributes that don't need a change.
+	Uid   *uint32
+	Gid   *uint32
 	Size  *uint64
 	Mode  *os.FileMode
 	Atime *time.Time


### PR DESCRIPTION
Hello, what do you think of this PR ?

It has been tested on Mac & Linux (on Linux where it worked in production for at least 1 year+)

Those are needed to be able to 100% pass a POSIX test suite at least on Linux (I used https://github.com/pjd/pjdfstest) 

This PR adds ability :
- to "receive" requests to change set-UID/set-GID/sticky-bit `(chmod u+s / g+s / +t)` in `.SetInodeAttributes()`
- to figure out the "context" (UID/GID) of the user land processus invoking a syscall
(I think I probably needed this one to have newly created `inode` be POSIX-compliant (have the correct `uid:gid` and/or maybe some stick-bit group folder stuff, I don't remember)

Mac : I didn't verified the correctness or meaningfulness of those fields, but at least it doesn't prevent anything from working.
Linux : It works as expected.
Windows : Didn't tested at all.