### PR TITLE
Add device number support, publish file mode conversion functions

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -209,6 +209,7 @@ func convertInMessage(
 			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
 			Name:   string(name),
 			Mode:   convertFileMode(in.Mode),
+			Rdev:   in.Rdev,
 			OpContext: fuseops.OpContext{
 				FuseID: inMsg.Header().Unique,
 				Pid:    inMsg.Header().Pid,
@@ -1006,6 +1007,10 @@ func convertAttributes(
 	}
 	if in.Mode&os.ModeSticky != 0 {
 		out.Mode |= syscall.S_ISVTX
+	}
+
+	if out.Mode&(syscall.S_IFCHR|syscall.S_IFBLK) != 0 {
+		out.Rdev = in.Rdev
 	}
 }
 

--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -304,6 +304,9 @@ type MkNodeOp struct {
 	Name string
 	Mode os.FileMode
 
+	// The device number (only valid if created file is a device)
+	Rdev uint32
+
 	// Set by the file system: information about the inode that was created.
 	//
 	// The lookup count for the inode is implicitly incremented. See notes on

--- a/fuseops/simple_types.go
+++ b/fuseops/simple_types.go
@@ -87,6 +87,9 @@ type InodeAttributes struct {
 	//
 	Mode os.FileMode
 
+	// The device number. Only valid if the file is a device
+	Rdev uint32
+
 	// Time information. See `man 2 stat` for full details.
 	Atime  time.Time // Time of last access
 	Mtime  time.Time // Time of last modification


### PR DESCRIPTION
Hi

1) I recently discovered that the library lacked device number support and added it.
2) File modes used by Golang and GeeseFS are different so it's handy for file systems to have library conversion functions so I published them.