### PR TITLE
Expose FuseID via OpContext

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -51,15 +51,21 @@ func convertInMessage(
 		}
 
 		o = &fuseops.LookUpInodeOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(buf[:n-1]),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(buf[:n-1]),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpGetattr:
 		o = &fuseops.GetInodeAttributesOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpSetattr:
@@ -70,8 +76,11 @@ func convertInMessage(
 		}
 
 		to := &fuseops.SetInodeAttributesOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 		o = to
 
@@ -116,9 +125,12 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ForgetInodeOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			N:         in.Nlookup,
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			N:     in.Nlookup,
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpBatchForget:
@@ -143,8 +155,11 @@ func convertInMessage(
 		}
 
 		o = &fuseops.BatchForgetOp{
-			Entries:   entries,
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Entries: entries,
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpMkdir:
@@ -170,8 +185,11 @@ func convertInMessage(
 			// the fact that this is a directory is implicit in the fact that the
 			// opcode is mkdir. But we want the correct mode to go through, so ensure
 			// that os.ModeDir is set.
-			Mode:      convertFileMode(in.Mode) | os.ModeDir,
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Mode: convertFileMode(in.Mode) | os.ModeDir,
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpMknod:
@@ -188,10 +206,13 @@ func convertInMessage(
 		name = name[:i]
 
 		o = &fuseops.MkNodeOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(name),
-			Mode:      convertFileMode(in.Mode),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(name),
+			Mode:   convertFileMode(in.Mode),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpCreate:
@@ -208,10 +229,13 @@ func convertInMessage(
 		name = name[:i]
 
 		o = &fuseops.CreateFileOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(name),
-			Mode:      convertFileMode(in.Mode),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(name),
+			Mode:   convertFileMode(in.Mode),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpSymlink:
@@ -227,10 +251,13 @@ func convertInMessage(
 		newName, target := names[0:i], names[i+1:len(names)-1]
 
 		o = &fuseops.CreateSymlinkOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(newName),
-			Target:    string(target),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(newName),
+			Target: string(target),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpRename:
@@ -272,7 +299,10 @@ func convertInMessage(
 			OldName:   string(oldName),
 			NewParent: fuseops.InodeID(in.Newdir),
 			NewName:   string(newName),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpUnlink:
@@ -283,9 +313,12 @@ func convertInMessage(
 		}
 
 		o = &fuseops.UnlinkOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(buf[:n-1]),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(buf[:n-1]),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpRmdir:
@@ -296,9 +329,12 @@ func convertInMessage(
 		}
 
 		o = &fuseops.RmDirOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(buf[:n-1]),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(buf[:n-1]),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpOpen:
@@ -311,13 +347,19 @@ func convertInMessage(
 		o = &fuseops.OpenFileOp{
 			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
 			OpenFlags: fusekernel.OpenFlags(in.Flags),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpOpendir:
 		o = &fuseops.OpenDirOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpRead:
@@ -327,11 +369,14 @@ func convertInMessage(
 		}
 
 		to := &fuseops.ReadFileOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			Offset:    int64(in.Offset),
-			Size:      int64(in.Size),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			Offset: int64(in.Offset),
+			Size:   int64(in.Size),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 		if !config.UseVectoredRead {
 			// Use part of the incoming message storage as the read buffer
@@ -347,10 +392,13 @@ func convertInMessage(
 		}
 
 		to := &fuseops.ReadDirOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			Offset:    fuseops.DirOffset(in.Offset),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			Offset: fuseops.DirOffset(in.Offset),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 		o = to
 
@@ -373,8 +421,11 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseFileHandleOp{
-			Handle:    fuseops.HandleID(in.Fh),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Handle: fuseops.HandleID(in.Fh),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpReleasedir:
@@ -385,8 +436,11 @@ func convertInMessage(
 		}
 
 		o = &fuseops.ReleaseDirHandleOp{
-			Handle:    fuseops.HandleID(in.Fh),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Handle: fuseops.HandleID(in.Fh),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpWrite:
@@ -401,11 +455,14 @@ func convertInMessage(
 		}
 
 		o = &fuseops.WriteFileOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			Data:      buf,
-			Offset:    int64(in.Offset),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			Data:   buf,
+			Offset: int64(in.Offset),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpFsync, fusekernel.OpFsyncdir:
@@ -416,9 +473,12 @@ func convertInMessage(
 		}
 
 		o = &fuseops.SyncFileOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpFlush:
@@ -429,15 +489,21 @@ func convertInMessage(
 		}
 
 		o = &fuseops.FlushFileOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpReadlink:
 		o = &fuseops.ReadSymlinkOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpStatfs:
@@ -485,10 +551,13 @@ func convertInMessage(
 		}
 
 		o = &fuseops.CreateLinkOp{
-			Parent:    fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(name),
-			Target:    fuseops.InodeID(in.Oldnodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Parent: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:   string(name),
+			Target: fuseops.InodeID(in.Oldnodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpRemovexattr:
@@ -499,9 +568,12 @@ func convertInMessage(
 		}
 
 		o = &fuseops.RemoveXattrOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(buf[:n-1]),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:  string(buf[:n-1]),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 
 	case fusekernel.OpGetxattr:
@@ -519,9 +591,12 @@ func convertInMessage(
 		name = name[:i]
 
 		to := &fuseops.GetXattrOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(name),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:  string(name),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 		o = to
 
@@ -548,8 +623,11 @@ func convertInMessage(
 		}
 
 		to := &fuseops.ListXattrOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid,
+			},
 		}
 		o = to
 
@@ -584,11 +662,13 @@ func convertInMessage(
 		name, value := payload[:i], payload[i+1:len(payload)]
 
 		o = &fuseops.SetXattrOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Name:      string(name),
-			Value:     value,
-			Flags:     in.Flags,
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode: fuseops.InodeID(inMsg.Header().Nodeid),
+			Name:  string(name),
+			Value: value,
+			Flags: in.Flags,
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid},
 		}
 	case fusekernel.OpFallocate:
 		type input fusekernel.FallocateIn
@@ -598,12 +678,14 @@ func convertInMessage(
 		}
 
 		o = &fuseops.FallocateOp{
-			Inode:     fuseops.InodeID(inMsg.Header().Nodeid),
-			Handle:    fuseops.HandleID(in.Fh),
-			Offset:    in.Offset,
-			Length:    in.Length,
-			Mode:      in.Mode,
-			OpContext: fuseops.OpContext{Pid: inMsg.Header().Pid},
+			Inode:  fuseops.InodeID(inMsg.Header().Nodeid),
+			Handle: fuseops.HandleID(in.Fh),
+			Offset: in.Offset,
+			Length: in.Length,
+			Mode:   in.Mode,
+			OpContext: fuseops.OpContext{
+				FuseID: inMsg.Header().Unique,
+				Pid:    inMsg.Header().Pid},
 		}
 
 	default:

--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -28,6 +28,9 @@ import (
 // OpContext contains extra context that may be needed by some file systems.
 // See https://libfuse.github.io/doxygen/structfuse__context.html as a reference.
 type OpContext struct {
+	// FuseID is the Unique identifier for each operation from the kernel.
+	FuseID uint64
+
 	// PID of the process that is invoking the operation.
 	// Not filled in case of a writepage operation.
 	Pid uint32

--- a/fuseutil/dirent.go
+++ b/fuseutil/dirent.go
@@ -50,7 +50,7 @@ type Dirent struct {
 	Type DirentType
 }
 
-// Write the supplied directory entry intto the given buffer in the format
+// Write the supplied directory entry into the given buffer in the format
 // expected in fuseops.ReadFileOp.Data, returning the number of bytes written.
 // Return zero if the entry would not fit.
 func WriteDirent(buf []byte, d Dirent) (n int) {


### PR DESCRIPTION
Would you be open to including the unique FuseID in the OpContext passed to every FUSE operation?

This would allow downstream functions/methods to include that number in detailed log messages, tying those messages back to the `Op` identifier in existing `debugLogger` output.  As it is, when multiple calls are active, correlating the messages can be difficult.
