### PR TITLE
Updating go version 1.19 to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/fuse
 
-go 1.19
+go 1.20
 
 require (
 	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e


### PR DESCRIPTION
These changes are required for upgrading go to 1.20 in GCSFuse: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/go.mod

To fix this issue - https://github.com/GoogleCloudPlatform/gcsfuse/issues/1071