### PR TITLE
Suppressing the error log in case of function not implemented

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -454,7 +454,7 @@ func (c *Connection) shouldLogError(
 			return false
 		}
 	case *fuseops.GetXattrOp, *fuseops.ListXattrOp:
-		if err == syscall.ENODATA || err == syscall.ERANGE {
+		if err == syscall.ENOSYS || err == syscall.ENODATA || err == syscall.ERANGE {
 			return false
 		}
 	case *unknownOp:


### PR DESCRIPTION
GCSFuse File system started throwing sys.ENOSYS error for GetXAttrs and ListXAttrs.
Please refer - https://github.com/GoogleCloudPlatform/gcsfuse/pull/1046

**Before this change:**
When gcsfuse is mounted with `--debug_fuse_errors` flag, it started showing as error log, which is an expected error.

**After this change:**
GCSFuse will not print the error log for the above mentioned case.