### PR TITLE
Add support for callbacks in ReadFile and WriteFile operations

### DIFF
--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -697,6 +697,11 @@ type ReadFileOp struct {
 	// If direct IO is enabled, semantics should match those of read(2).
 	BytesRead int
 	OpContext OpContext
+
+	// If set, this function will be invoked after the operation response has been
+	// sent to the kernel and before the buffers containing the response data are
+	// freed.
+	Callback func()
 }
 
 // Write data to a file previously opened with CreateFile or OpenFile.
@@ -757,6 +762,11 @@ type WriteFileOp struct {
 	// page at a time.
 	Data      []byte
 	OpContext OpContext
+
+	// If set, this function will be invoked after the operation response has been
+	// sent to the kernel and before the buffers containing the response data are
+	// freed.
+	Callback func()
 }
 
 // Synchronize the current contents of an open file to storage.

--- a/samples/memfs/callback_test.go
+++ b/samples/memfs/callback_test.go
@@ -1,0 +1,81 @@
+package memfs_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/jacobsa/fuse/samples"
+	"github.com/jacobsa/fuse/samples/memfs"
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestFuseServerCallbacks(t *testing.T) { RunTests(t) }
+
+type CallbackTest struct {
+	samples.SampleTest
+	readFileCallbackInvoked  bool
+	writeFileCallbackInvoked bool
+}
+
+func init() { RegisterTestSuite(&CallbackTest{}) }
+
+func (t *CallbackTest) SetUp(ti *TestInfo) {
+	t.MountConfig.DisableWritebackCaching = true
+	t.readFileCallbackInvoked = false
+	t.writeFileCallbackInvoked = false
+
+	t.Server = memfs.NewMemFSWithCallbacks(
+		currentUid(),
+		currentGid(),
+		func() { t.readFileCallbackInvoked = true },
+		func() { t.writeFileCallbackInvoked = true },
+	)
+	t.SampleTest.SetUp(ti)
+}
+
+// The test suite is torn down during the test to ensure
+// that all FUSE operations are complete before checking
+// the invocations on the callbacks.
+func (t *CallbackTest) TearDown() {}
+
+func (t *CallbackTest) TestCallbacksInvokedForWriteFile() {
+	AssertEq(t.writeFileCallbackInvoked, false)
+	AssertEq(t.readFileCallbackInvoked, false)
+
+	// Write a file.
+	fileName := path.Join(t.Dir, memfs.CheckFileOpenFlagsFileName)
+	const contents = "Hello world"
+	err := os.WriteFile(fileName, []byte(contents), 0400)
+	AssertEq(nil, err)
+
+	// Tear down the FUSE mount. This ensures that all FUSE operations are complete.
+	t.SampleTest.TearDown()
+
+	// Check that our callback was invoked as expected.
+	AssertEq(t.writeFileCallbackInvoked, true)
+	AssertEq(t.readFileCallbackInvoked, false)
+}
+
+func (t *CallbackTest) TestCallbacksInvokedForWriteFileAndReadFile() {
+	AssertEq(t.writeFileCallbackInvoked, false)
+	AssertEq(t.readFileCallbackInvoked, false)
+
+	// Write a file.
+	fileName := path.Join(t.Dir, memfs.CheckFileOpenFlagsFileName)
+	const contents = "Hello world"
+	err := os.WriteFile(fileName, []byte(contents), 0400)
+	AssertEq(nil, err)
+
+	// Read it back.
+	slice, err := os.ReadFile(fileName)
+	AssertEq(nil, err)
+	ExpectEq(contents, string(slice))
+
+	// Tear down the FUSE mount. This ensures that all FUSE operations are complete.
+	t.SampleTest.TearDown()
+
+	// Check that our callback was invoked as expected.
+	AssertEq(t.writeFileCallbackInvoked, true)
+	AssertEq(t.readFileCallbackInvoked, true)
+}

--- a/samples/memfs/memfs_test.go
+++ b/samples/memfs/memfs_test.go
@@ -1903,27 +1903,6 @@ func (t *MemFSTest) RemoveXAttr() {
 	AssertEq(fuse.ENOATTR, err)
 }
 
-func (t *MemFSTest) ReadFileCallback() {
-	var err error
-
-	// Create a file
-	filePath := path.Join(t.Dir, "foo")
-	err = ioutil.WriteFile(filePath, []byte("taco"), 0600)
-	AssertEq(nil, err)
-
-	err = unix.Removexattr(filePath, "foo")
-	AssertEq(fuse.ENOATTR, err)
-
-	err = unix.Setxattr(filePath, "foo", []byte("bar"), unix.XATTR_CREATE)
-	AssertEq(nil, err)
-
-	err = unix.Removexattr(filePath, "foo")
-	AssertEq(nil, err)
-
-	_, err = unix.Getxattr(filePath, "foo", nil)
-	AssertEq(fuse.ENOATTR, err)
-}
-
 ////////////////////////////////////////////////////////////////////////
 // Mknod
 ////////////////////////////////////////////////////////////////////////

--- a/samples/memfs/memfs_test.go
+++ b/samples/memfs/memfs_test.go
@@ -1903,6 +1903,27 @@ func (t *MemFSTest) RemoveXAttr() {
 	AssertEq(fuse.ENOATTR, err)
 }
 
+func (t *MemFSTest) ReadFileCallback() {
+	var err error
+
+	// Create a file
+	filePath := path.Join(t.Dir, "foo")
+	err = ioutil.WriteFile(filePath, []byte("taco"), 0600)
+	AssertEq(nil, err)
+
+	err = unix.Removexattr(filePath, "foo")
+	AssertEq(fuse.ENOATTR, err)
+
+	err = unix.Setxattr(filePath, "foo", []byte("bar"), unix.XATTR_CREATE)
+	AssertEq(nil, err)
+
+	err = unix.Removexattr(filePath, "foo")
+	AssertEq(nil, err)
+
+	_, err = unix.Getxattr(filePath, "foo", nil)
+	AssertEq(fuse.ENOATTR, err)
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Mknod
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
An alternative to https://github.com/jacobsa/fuse/pull/144

One downside to the MessageProvider introduced in https://github.com/jacobsa/fuse/pull/144 is that the FUSE server will need to be able to link a FUSE operation (ReadFile, WriteFile, etc) with the calls to `putInMessage` and `putOutMessage` so that the FUSE server knows which Write / Read has completed. Presumably, this forces the FUSE server to maintain some map with the FuseId as the key.

In contrast, the approach in this PR allows the FUSE server to specify the Callback function directly in the ReadFile or WriteFile operation, so the FUSE server does not need to maintain a map of FuseIds.

Like the other PR, this change allows us to both get notified when a response is sent to the kernel and also block the recycling of the inMessage and outMessage buffers. This change is slightly preferable for us because it allows us to skip the map with FuseIds. This also seems to be a less intrusive change than the other PR (for example, we don't need to expose the buffer package).

However, there are a couple of downsides to this change:
1. The fact that these callbacks will block recycling of the inMessage and outMessage buffers is not immediately obvious and I don't yet know of a good way to add a test to guarantee this behavior.
2. There is no way to control the inMessage and outMessage behavior independently (this is fine for our use case, but maybe you prefer a more fine-grained solution for potential future use cases).
3. There is no way to control getInMessage and getOutMessage (again, this is fine for our use case, but maybe you prefer something more general for future use cases)