### PR TITLE
Add a config to allocate the read buffer when vectored reads are enabled

### DIFF
--- a/fuseops/ops.go
+++ b/fuseops/ops.go
@@ -678,7 +678,11 @@ type ReadFileOp struct {
 	Size int64
 
 	// The destination buffer, whose length gives the size of the read.
-	// For vectored reads, this field is always nil as the buffer is not provided.
+	// For vectored reads, this field is nil unless the file system explicitly
+	// asks for it to be provided with the AllocateReadBufferForVectoredRead flag.
+	// If vectored reads and AllocateReadBufferForVectoredRead are enabled, this
+	// buffer must be appended to Data if the file system wants it to be returned
+	// to the kernel.
 	Dst []byte
 
 	// Set by the file system:

--- a/mount_config.go
+++ b/mount_config.go
@@ -159,9 +159,18 @@ type MountConfig struct {
 	// Use vectored reads.
 	// Vectored read allows file systems to avoid memory copying overhead if
 	// the data is already in memory when they return it to FUSE.
-	// When turned on, ReadFileOp.Dst is always nil and the FS must return data
-	// being read from the file as a list of slices in ReadFileOp.Data.
+	// When turned on, the FS must return data being read from the file as a
+	// list of slices in ReadFileOp.Data.
 	UseVectoredRead bool
+
+	// If vectored reads are enabled, the ReadFileOp.Dst buffer is nil by default.
+	// However, some file systems may still want the Dst buffer to be allocated in
+	// case they need space to hold the read data in memory. It is efficient to use
+	// the Dst buffer for this case because it reuses memory that was already
+	// allocated to read the kernel operation. However, if this flag is enabled,
+	// the file system must append the Dst buffer to ReadFileOp.Data if it wants
+	// the Dst buffer to be included in the response to the kernel.
+	AllocateReadBufferForVectoredRead bool
 
 	// OS X only.
 	//

--- a/samples/memfs/memfs.go
+++ b/samples/memfs/memfs.go
@@ -627,7 +627,7 @@ func (fs *memFS) OpenFile(
 		// Set attribute (name=fileOpenFlagsXattr, value=OpenFlags) to test whether
 		// we set OpenFlags correctly. The value is checked in test with getXattr.
 		value := make([]byte, 4)
-		binary.LittleEndian.PutUint32(value, uint32(op.OpenFlags))
+		binary.LittleEndian.PutUint32(value, uint32(op.OpenFlags)&syscall.O_ACCMODE)
 		err := fs.setXattrHelper(inode, &fuseops.SetXattrOp{
 			Name:  FileOpenFlagsXattrName,
 			Value: value,

--- a/samples/vectorreadfs/vector_read_test.go
+++ b/samples/vectorreadfs/vector_read_test.go
@@ -1,0 +1,199 @@
+package vector_read_fs_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/jacobsa/fuse"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"github.com/jacobsa/fuse/samples"
+	. "github.com/jacobsa/ogletest"
+)
+
+func TestVectorRead(t *testing.T) { RunTests(t) }
+
+type VectorReadTest struct {
+	samples.SampleTest
+	vectorReadFs *vectorReadFs
+	testInfo     *TestInfo
+}
+
+func init() { RegisterTestSuite(&VectorReadTest{}) }
+
+const testFileSize = 1024
+const testFileName = "testFileName"
+
+// A simple file system implementation that only exposes the
+// existence of a single test file for reading and allows
+// tests to implement custom read functions.
+type vectorReadFs struct {
+	fuseutil.NotImplementedFileSystem
+	readFileFn func(ctx context.Context, op *fuseops.ReadFileOp) error
+}
+
+func (fs *vectorReadFs) StatFS(ctx context.Context, op *fuseops.StatFSOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) LookUpInode(ctx context.Context, op *fuseops.LookUpInodeOp) error {
+	if op.Name == testFileName {
+		op.Entry = fuseops.ChildInodeEntry{
+			Child: 2,
+			Attributes: fuseops.InodeAttributes{
+				Size:  testFileSize,
+				Nlink: 1,
+				Mode:  0444,
+			},
+		}
+		return nil
+	}
+	return fuse.ENOENT
+}
+
+func (fs *vectorReadFs) GetInodeAttributes(ctx context.Context, op *fuseops.GetInodeAttributesOp) error {
+	if op.Inode == 1 {
+		op.Attributes = fuseops.InodeAttributes{
+			Nlink: 1,
+			Mode:  0755 | os.ModeDir,
+		}
+		return nil
+	} else if op.Inode == 2 {
+		op.Attributes = fuseops.InodeAttributes{
+			Size:  testFileSize,
+			Nlink: 1,
+			Mode:  0444,
+		}
+		return nil
+	}
+	return fuse.ENOENT
+}
+
+func (fs *vectorReadFs) OpenDir(ctx context.Context, op *fuseops.OpenDirOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) ReadDir(ctx context.Context, op *fuseops.ReadDirOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) ReadFile(ctx context.Context, op *fuseops.ReadFileOp) error {
+	if fs.readFileFn != nil {
+		return fs.readFileFn(ctx, op)
+	}
+	return nil
+}
+
+func (fs *vectorReadFs) ReleaseDirHandle(ctx context.Context, op *fuseops.ReleaseDirHandleOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) GetXattr(ctx context.Context, op *fuseops.GetXattrOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) ListXattr(ctx context.Context, op *fuseops.ListXattrOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) ForgetInode(ctx context.Context, op *fuseops.ForgetInodeOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) ReleaseFileHandle(ctx context.Context, op *fuseops.ReleaseFileHandleOp) error {
+	return nil
+}
+
+func (fs *vectorReadFs) FlushFile(ctx context.Context, op *fuseops.FlushFileOp) error {
+	return nil
+}
+
+func (t *VectorReadTest) SetUp(ti *TestInfo) {
+	t.vectorReadFs = &vectorReadFs{}
+	t.Server = fuseutil.NewFileSystemServer(t.vectorReadFs)
+	t.testInfo = ti
+}
+
+func (t *VectorReadTest) TestReadBufferAllocated() {
+	// Set up the fuse server config to allocate read buffers
+	t.MountConfig.UseVectoredRead = true
+	t.MountConfig.AllocateReadBufferForVectoredRead = true
+	t.SampleTest.SetUp(t.testInfo)
+
+	// Use a custom read function that verifies the presence of the pre-allocated Dst buffer
+	t.vectorReadFs.readFileFn = func(ctx context.Context, op *fuseops.ReadFileOp) error {
+		if op.Dst == nil {
+			return fuse.EIO
+		}
+		if int64(len(op.Dst)) != op.Size {
+			return fuse.EINVAL
+		}
+
+		op.BytesRead = int(op.Size)
+		if testFileSize-int(op.Offset) < int(op.Size) {
+			op.BytesRead = testFileSize - int(op.Offset)
+		}
+
+		t.generateFileContent(op.Dst[:op.BytesRead])
+		op.Data = append(op.Data, op.Dst[:op.BytesRead])
+		return nil
+	}
+
+	// Read the test file and verify the output
+	fileName := path.Join(t.Dir, testFileName)
+	fileContent, err := os.ReadFile(fileName)
+	AssertEq(nil, err)
+	AssertEq(testFileSize, len(fileContent))
+
+	expectedContent := make([]byte, testFileSize)
+	t.generateFileContent(expectedContent)
+	ExpectEq(string(expectedContent), string(fileContent))
+}
+
+func (t *VectorReadTest) TestReadBufferNotAllocated() {
+	// Set up the fuse server config to use vectored reads but not to allocate read buffers
+	t.MountConfig.UseVectoredRead = true
+	t.MountConfig.AllocateReadBufferForVectoredRead = false
+	t.SampleTest.SetUp(t.testInfo)
+
+	// Use a custom read function that verifies that the Dst buffer is not pre-allocated
+	t.vectorReadFs.readFileFn = func(ctx context.Context, op *fuseops.ReadFileOp) error {
+		if op.Dst != nil {
+			return fuse.EIO
+		}
+
+		op.BytesRead = int(op.Size)
+		if testFileSize-int(op.Offset) < int(op.Size) {
+			op.BytesRead = testFileSize - int(op.Offset)
+		}
+
+		buf := make([]byte, op.BytesRead)
+		t.generateFileContent(buf)
+		op.Data = append(op.Data, buf)
+		return nil
+	}
+
+	// Read the test file and verify the output
+	fileName := path.Join(t.Dir, testFileName)
+	fileContent, err := os.ReadFile(fileName)
+	AssertEq(nil, err)
+	AssertEq(testFileSize, len(fileContent))
+
+	expectedContent := make([]byte, testFileSize)
+	t.generateFileContent(expectedContent)
+	ExpectEq(string(expectedContent), string(fileContent))
+}
+
+// Fills the input buffer with sequentially increasing bytes. The sequence length
+// is prime to help detect duplication errors.
+func (t *VectorReadTest) generateFileContent(buf []byte) {
+	for i := 0; i < len(buf); i++ {
+		buf[i] = byte(i % 199)
+	}
+}


### PR DESCRIPTION
Currently, when vector reads are enabled, this FUSE library stops providing the pre-allocated read buffer. We would like to use vectored reads, but the pre-allocated read buffer is still very useful for us.

Our application prefetches data from the cloud, but sometimes the kernel will ask for data faster than we can prefetch it, in which case we need a buffer to read the data into from over the network. Without using vectored reads, we can make use of the pre-allocated read buffer. This is very efficient because the pre-allocated read buffer uses extra space from the buffer that reads operations from the kernel.

This change proposes adding another config that would allow the ReadFileOp.Dst buffer to be allocated for vectored reads. The file system implementation can choose to add data to ReadFileOp.Dst if it desires, and it must append ReadFileOp.Dst to ReadFileOp.Data if it wants the data to be included in the response to the kernel.