### PR TITLE
fusetesting: fix compilation on arm64 where syscall.Stat_t is a uint32

### DIFF
--- a/fusetesting/stat_linux.go
+++ b/fusetesting/stat_linux.go
@@ -28,7 +28,7 @@ func extractBirthtime(sys interface{}) (birthtime time.Time, ok bool) {
 }
 
 func extractNlink(sys interface{}) (nlink uint64, ok bool) {
-	return sys.(*syscall.Stat_t).Nlink, true
+	return uint64(sys.(*syscall.Stat_t).Nlink), true
 }
 
 func getTimes(stat *syscall.Stat_t) (atime, ctime, mtime time.Time) {


### PR DESCRIPTION
Previously it was returning uint32 value. Fixing that by converting return type to uint64.
