### PR TITLE
upgrade go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jacobsa/fuse
 
-go 1.20
+go 1.21
 
 require (
 	github.com/detailyang/go-fallocate v0.0.0-20180908115635-432fa640bd2e


### PR DESCRIPTION
Upgrade to go version 1.21 as it fixes security vulnerabilities.

Issue: https://github.com/GoogleCloudPlatform/gcsfuse/issues/1288