### PR TITLE
Add PARALLEL_DIROPS FUSE option to jacobsa/fuse

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -193,6 +193,11 @@ func (c *Connection) Init() error {
 		initOp.Flags |= fusekernel.InitNoOpendirSupport
 	}
 
+	// Tell the Kernel to allow sending parallel lookup and readdir operations.
+	if c.cfg.EnableParallelDirOps {
+		initOp.Flags |= fusekernel.InitParallelDirOps
+	}
+
 	return c.Reply(ctx, nil)
 }
 

--- a/internal/fusekernel/fuse_kernel.go
+++ b/internal/fusekernel/fuse_kernel.go
@@ -266,6 +266,7 @@ const (
 	InitAsyncDIO         InitFlags = 1 << 15
 	InitWritebackCache   InitFlags = 1 << 16
 	InitNoOpenSupport    InitFlags = 1 << 17
+	InitParallelDirOps   InitFlags = 1 << 18
 	InitMaxPages         InitFlags = 1 << 22
 	InitCacheSymlinks    InitFlags = 1 << 23
 	InitNoOpendirSupport InitFlags = 1 << 24

--- a/mount_config.go
+++ b/mount_config.go
@@ -185,6 +185,11 @@ type MountConfig struct {
 	// Flag to enable async reads that are received from
 	// the kernel
 	EnableAsyncReads bool
+
+	// Flag to enable parallel lookup and readdir operations from the
+	// kernel
+	// Ref: https://github.com/torvalds/linux/commit/5c672ab3f0ee0f78f7acad183f34db0f8781a200
+	EnableParallelDirOps bool
 }
 
 // Create a map containing all of the key=value mount options to be given to


### PR DESCRIPTION
Add PARALLEL_DIROPS FUSE option to jacobsa/fuse. When enabled, this allows parallel lookups and readdir calls to filesystem server in user space from FUSE driver.

Consider the directory and file structure is flat i.e. 
mnt/ 
   - child1.txt
   - child2.txt
   - ...
   - childN.txt
  
When PARALLEL_DIROPS is not enabled:
if an application tries to stat the child files parallely, for the first time, the calls are serialized from FUSE driver to filesystem server in user space. When the same files are accessed second time, the calls are parallel.

When PARALLEL_DIROPS is enabled:
if an application tries to stat the child files parallely, the calls are parallel from FUSE driver to filesystem server in user space. 

