### PR TITLE
Fix IO performance regression 

### DIFF
--- a/samples/roloopbackfs/inode.go
+++ b/samples/roloopbackfs/inode.go
@@ -116,12 +116,12 @@ func (in *inodeEntry) ListChildren(inodes *sync.Map) ([]*fuseutil.Dirent, error)
 	if err != nil {
 		return nil, err
 	}
-	dirents := make([]*fuseutil.Dirent, len(children))
+	dirents := []*fuseutil.Dirent{}
 	for i, child := range children {
 
 		childInode, err := getOrCreateInode(inodes, in.id, child.Name())
 		if err != nil || childInode == nil {
-			return nil, nil
+			continue
 		}
 
 		var childType fuseutil.DirentType
@@ -133,12 +133,12 @@ func (in *inodeEntry) ListChildren(inodes *sync.Map) ([]*fuseutil.Dirent, error)
 			childType = fuseutil.DT_File
 		}
 
-		dirents[i] = &fuseutil.Dirent{
+		dirents = append(dirents, &fuseutil.Dirent{
 			Offset: fuseops.DirOffset(i + 1),
 			Inode:  childInode.Id(),
 			Name:   child.Name(),
 			Type:   childType,
-		}
+		})
 	}
 	return dirents, nil
 }


### PR DESCRIPTION
Following @sethiay regression report, restrict writev locking to macOS fuse-t platform. 
Also corrects an issue with special folders handling such as "Google Drive" in loopbackfs.