### PR TITLE
Adds file handle in OpenFile and ReleaseFileHandle logs

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -115,6 +115,9 @@ func describeRequest(op interface{}) (s string) {
 		addComponent("offset %d", typed.Offset)
 		addComponent("length %d", typed.Length)
 		addComponent("mode %d", typed.Mode)
+
+	case *fuseops.ReleaseFileHandleOp:
+		addComponent("Handle %d", typed.Handle)
 	}
 
 	// Use just the name if there is no extra info.
@@ -140,6 +143,11 @@ func describeResponse(op interface{}) string {
 		if entry, ok := f.Interface().(fuseops.ChildInodeEntry); ok {
 			addComponent("inode %v", entry.Child)
 		}
+	}
+
+	switch typed := op.(type) {
+	case *fuseops.OpenFileOp:
+		addComponent("Handle %d", typed.Handle)
 	}
 
 	return fmt.Sprintf("%s", strings.Join(components, ", "))

--- a/debug.go
+++ b/debug.go
@@ -117,7 +117,7 @@ func describeRequest(op interface{}) (s string) {
 		addComponent("mode %d", typed.Mode)
 
 	case *fuseops.ReleaseFileHandleOp:
-		addComponent("Handle %d", typed.Handle)
+		addComponent("handle %d", typed.Handle)
 	}
 
 	// Use just the name if there is no extra info.
@@ -147,7 +147,7 @@ func describeResponse(op interface{}) string {
 
 	switch typed := op.(type) {
 	case *fuseops.OpenFileOp:
-		addComponent("Handle %d", typed.Handle)
+		addComponent("handle %d", typed.Handle)
 	}
 
 	return fmt.Sprintf("%s", strings.Join(components, ", "))


### PR DESCRIPTION
### Description
As of now OpenFile and ReleaseFileHandle logs do not have file handles. In order to analyse logs, one needs to know which handle is assigned to a file when it is opened and when closing which handle is being released.
### Link to the issue in case of a bug fix
NA
### Testing Details

1. Manual - Manually verified with GCSFuse that logs are printing file handles as expected:
```
{"timestamp":{"seconds":1717657690,"nanos":285345660},"severity":"TRACE","message":"fuse_debug: Op 0x0000001a        connection.go:420] <- OpenFile (inode 2, PID 1159034)"}
{"timestamp":{"seconds":1717657690,"nanos":285426200},"severity":"TRACE","message":"fuse_debug: Op 0x0000001a        connection.go:513] -> OK (Handle 1)"}
```

```
{"timestamp":{"seconds":1717657690,"nanos":285835240},"severity":"TRACE","message":"fuse_debug: Op 0x0000001e        connection.go:420] <- ReleaseFileHandle (PID 0, Handle 1)"}
```
2. Unit tests - NA
3. Integration tests - NA 
