### PR TITLE
Improving fuse response log for better debuggability

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -510,7 +510,7 @@ func (c *Connection) Reply(ctx context.Context, opErr error) error {
 	// Debug logging
 	if c.debugLogger != nil {
 		if opErr == nil {
-			c.debugLog(fuseID, 1, "-> OK (%s)", describeResponse(op))
+			c.debugLog(fuseID, 1, "-> %s", describeResponse(op))
 		} else {
 			c.debugLog(fuseID, 1, "-> Error: %q", opErr.Error())
 		}

--- a/debug.go
+++ b/debug.go
@@ -144,11 +144,10 @@ func describeResponse(op interface{}) string {
 			addComponent("inode %v", entry.Child)
 		}
 	}
-
 	switch typed := op.(type) {
 	case *fuseops.OpenFileOp:
 		addComponent("handle %d", typed.Handle)
 	}
 
-	return fmt.Sprintf("%s", strings.Join(components, ", "))
+	return fmt.Sprintf("%s (%s)", opName(op), strings.Join(components, ", "))
 }


### PR DESCRIPTION
Currently, fuse response log `OK ()` is pretty generic. Replacing the `OK` with operation name. This is specially useful in knowing if a particular operation `ReadFile` or `LookUpInode` is happening in parallel.

**Before**  
```
time="25/06/2024 03:05:52.093580" severity=TRACE message="fuse_debug: Op 0x00000160        connection.go:420] <- LookUpInode (parent 1, name \"b.txt\", PID 870932)"

time="25/06/2024 03:05:52.093777" severity=TRACE message="fuse_debug: Op 0x00000160        connection.go:513] -> OK (inode 2)"
```


**After**
```
time="25/06/2024 03:03:45.288441" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:420] <- LookUpInode (parent 1, name \"b.txt\", PID 869418)"

time="25/06/2024 03:03:45.505412" severity=TRACE message="fuse_debug: Op 0x0000015c        connection.go:513] -> LookUpInode (inode 3)"
```