### PR TITLE
Allow filesystems to set atomic_o_trunc flag

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -200,6 +200,10 @@ func (c *Connection) Init() error {
 		initOp.Flags |= fusekernel.InitParallelDirOps
 	}
 
+	if c.cfg.EnableAtomicTrunc {
+		initOp.Flags |= fusekernel.InitAtomicTrunc
+	}
+
 	return c.Reply(ctx, nil)
 }
 

--- a/mount_config.go
+++ b/mount_config.go
@@ -198,6 +198,8 @@ type MountConfig struct {
 	// kernel
 	// Ref: https://github.com/torvalds/linux/commit/5c672ab3f0ee0f78f7acad183f34db0f8781a200
 	EnableParallelDirOps bool
+
+	EnableAtomicTrunc bool
 }
 
 type FUSEImpl uint8

--- a/mount_config.go
+++ b/mount_config.go
@@ -199,6 +199,11 @@ type MountConfig struct {
 	// Ref: https://github.com/torvalds/linux/commit/5c672ab3f0ee0f78f7acad183f34db0f8781a200
 	EnableParallelDirOps bool
 
+	// Flag to enable atomic truncate during file open operations.
+	// When enabled, application calls to open with the O_TRUNC flag will cause a FUSE OpenFile
+	// op with the O_TRUNC flag set. In comparison, the default behavior is an OpenFile op
+	// without O_TRUNC, followed by a SetInodeAttributes op with the target size set to 0.
+	// Ref: https://github.com/torvalds/linux/commit/6ff958edbf39c014eb06b65ad25b736be08c4e63
 	EnableAtomicTrunc bool
 }
 

--- a/samples/memfs/memfs.go
+++ b/samples/memfs/memfs.go
@@ -640,7 +640,7 @@ func (fs *memFS) OpenFile(
 		// Set attribute (name=fileOpenFlagsXattr, value=OpenFlags) to test whether
 		// we set OpenFlags correctly. The value is checked in test with getXattr.
 		value := make([]byte, 4)
-		binary.LittleEndian.PutUint32(value, uint32(op.OpenFlags)&syscall.O_ACCMODE)
+		binary.LittleEndian.PutUint32(value, uint32(op.OpenFlags))
 		err := fs.setXattrHelper(inode, &fuseops.SetXattrOp{
 			Name:  FileOpenFlagsXattrName,
 			Value: value,

--- a/samples/memfs/memfs_test.go
+++ b/samples/memfs/memfs_test.go
@@ -90,19 +90,19 @@ func applyUmask(m os.FileMode) os.FileMode {
 	return m &^ os.FileMode(umask)
 }
 
-func (t *memFSTest) checkReadWriteOpenFlagsXattr(
+func (t *memFSTest) checkReadWriteOpenFlags(
 	fileName string, expectedOpenFlags fusekernel.OpenFlags) {
 	openFlags := t.getOpenFlagsXattr(fileName)
 	AssertEq(expectedOpenFlags, openFlags&fusekernel.OpenAccessModeMask)
 }
 
-func (t *memFSTest) checkOpenFlagsContainsFlagXattr(
+func (t *memFSTest) checkOpenFlagsContainsFlag(
 	fileName string, flag fusekernel.OpenFlags) {
 	openFlags := t.getOpenFlagsXattr(fileName)
 	AssertNe(0, openFlags&flag)
 }
 
-func (t *memFSTest) checkOpenFlagsNotContainsFlagXattr(
+func (t *memFSTest) checkOpenFlagsNotContainsFlag(
 	fileName string, flag fusekernel.OpenFlags) {
 	openFlags := t.getOpenFlagsXattr(fileName)
 	AssertEq(0, openFlags&flag)
@@ -348,7 +348,7 @@ func (t *MemFSTest) CreateNewFile_InRoot() {
 	slice, err := ioutil.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq(contents, string(slice))
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenReadOnly)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenReadOnly)
 }
 
 func (t *MemFSTest) CreateNewFile_InSubDir() {
@@ -410,7 +410,7 @@ func (t *MemFSTest) ModifyExistingFile_InRoot() {
 	f, err := os.OpenFile(fileName, os.O_WRONLY, 0400)
 	t.ToClose = append(t.ToClose, f)
 	AssertEq(nil, err)
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenWriteOnly)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenWriteOnly)
 
 	modifyTime := time.Now()
 	n, err = f.WriteAt([]byte("H"), 0)
@@ -439,7 +439,7 @@ func (t *MemFSTest) ModifyExistingFile_InRoot() {
 	slice, err := ioutil.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq("Hello, world!", string(slice))
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenReadOnly)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenReadOnly)
 }
 
 func (t *MemFSTest) ModifyExistingFile_InSubDir() {
@@ -870,7 +870,7 @@ func (t *MemFSTest) AppendMode() {
 	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_APPEND, 0600)
 	t.ToClose = append(t.ToClose, f)
 	AssertEq(nil, err)
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenReadWrite)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenReadWrite)
 
 	// Seek to somewhere silly and then write.
 	off, err = f.Seek(2, 0)
@@ -948,7 +948,7 @@ func (t *MemFSTest) Truncate_Smaller() {
 	f, err := os.OpenFile(fileName, os.O_RDWR, 0)
 	t.ToClose = append(t.ToClose, f)
 	AssertEq(nil, err)
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenReadWrite)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenReadWrite)
 
 	// Truncate it.
 	err = f.Truncate(2)
@@ -963,7 +963,7 @@ func (t *MemFSTest) Truncate_Smaller() {
 	contents, err := ioutil.ReadFile(fileName)
 	AssertEq(nil, err)
 	ExpectEq("ta", string(contents))
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenReadOnly)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenReadOnly)
 }
 
 func (t *MemFSTest) Truncate_SameSize() {
@@ -2064,12 +2064,12 @@ func (t *atomicOTruncTest) OpenFileWithOTrunc() {
 	AssertEq(nil, err)
 	defer f.Close()
 
-	t.checkReadWriteOpenFlagsXattr(fileName, fusekernel.OpenWriteOnly)
+	t.checkReadWriteOpenFlags(fileName, fusekernel.OpenWriteOnly)
 
 	if t.enableAtomicOTrunc {
-		t.checkOpenFlagsContainsFlagXattr(fileName, fusekernel.OpenTruncate)
+		t.checkOpenFlagsContainsFlag(fileName, fusekernel.OpenTruncate)
 	} else {
-		t.checkOpenFlagsNotContainsFlagXattr(fileName, fusekernel.OpenTruncate)
+		t.checkOpenFlagsNotContainsFlag(fileName, fusekernel.OpenTruncate)
 	}
 }
 


### PR DESCRIPTION
This PR implements the atomic_o_trunc flag during the fuse init protocol.

When this flag is enabled, application calls to `open` with the O_TRUNC flag will cause a FUSE OpenFile op with the O_TRUNC flag set. In comparison, the default behavior is an OpenFile op without O_TRUNC, followed by a SetInodeAttributes op with the target size set to 0.

Ref: https://github.com/torvalds/linux/commit/6ff958edbf39c014eb06b65ad25b736be08c4e63