### PR TITLE
Improving fuse error log for better debuggability

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -524,7 +524,11 @@ func (c *Connection) Reply(ctx context.Context, opErr error) error {
 
 	// Error logging
 	if c.shouldLogError(op, opErr) {
-		c.errorLogger.Printf("%T error: %v", op, opErr)
+		// Error logging
+		msg := fmt.Sprintf(
+			"Op 0x%08x %T] -> Error: %q",
+			fuseID, op, opErr)
+		c.errorLogger.Println(msg)
 	}
 
 	// Send the reply to the kernel, if one is required.


### PR DESCRIPTION
Currently, error logs lack operation IDs, which makes it difficult to correlate errors with specific requests during debugging. Adding the operation ID to the logs will significantly improve debugging efficiency.

Previously
```
{"timestamp":{"seconds":1740394276,"nanos":873104409},"severity":"TRACE","message":"fuse_debug: Op 0x00000166        connection.go:420] <- SyncFile (inode 2, PID 173511)"}
{"timestamp":{"seconds":1740394276,"nanos":897312524},"severity":"TRACE","message":"fuse_debug: Op 0x00000166        connection.go:513] -> Error: \"stale file handle\""}
{"timestamp":{"seconds":1740394276,"nanos":897321854},"severity":"ERROR","message":"fuse: *fuseops.SyncFileOp error: stale file handle"}
```

Now
```
{"timestamp":{"seconds":1740393686,"nanos":777589764},"severity":"TRACE","message":"fuse_debug: Op 0x00000168        connection.go:420] <- SyncFile (inode 2, PID 167380)"}
{"timestamp":{"seconds":1740394276,"nanos":897312524},"severity":"TRACE","message":"fuse_debug: Op 0x00000168         connection.go:513] -> Error: \"stale file handle\""}
{"timestamp":{"seconds":1740393686,"nanos":808585082},"severity":"ERROR","message":"fuse: Op 0x00000168      *fuseops.SyncFileOp] -> Error: \"stale file handle\""}
```

More info: [b/398756683](https://b.corp.google.com/issues/398756683)
