### PR TITLE
Remove debug log incase we are logging same as error log

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -513,19 +513,21 @@ func (c *Connection) Reply(ctx context.Context, opErr error) error {
 	// Clean up state for this op.
 	c.finishOp(inMsg.Header().Opcode, inMsg.Header().Unique)
 
+	logError := c.shouldLogError(op, opErr)
+
 	// Debug logging
 	if c.debugLogger != nil {
 		if opErr == nil {
 			c.debugLog(fuseID, 1, "-> %s", describeResponse(op))
 		} else {
-			if !c.shouldLogError(op, opErr) {
+			if !logError {
 				c.debugLog(fuseID, 1, "-> Error: %q", opErr.Error())
 			}
 		}
 	}
 
 	// Error logging
-	if c.shouldLogError(op, opErr) {
+	if logError {
 		c.errorLogger.Printf("Op 0x%08x %T] -> Error: %q", fuseID, op, opErr)
 	}
 

--- a/connection.go
+++ b/connection.go
@@ -518,7 +518,9 @@ func (c *Connection) Reply(ctx context.Context, opErr error) error {
 		if opErr == nil {
 			c.debugLog(fuseID, 1, "-> %s", describeResponse(op))
 		} else {
-			c.debugLog(fuseID, 1, "-> Error: %q", opErr.Error())
+			if !c.shouldLogError(op, opErr) {
+				c.debugLog(fuseID, 1, "-> Error: %q", opErr.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
If any error occurs the debug responses and error logs are essentially the same, we have removed the debug severity response logs, retaining only the error logs. This will also reduce the overall number of logs.
Previously
```
{"timestamp":{"seconds":1740394276,"nanos":873104409},"severity":"TRACE","message":"fuse_debug: Op 0x00000166        connection.go:420] <- SyncFile (inode 2, PID 173511)"}
{"timestamp":{"seconds":1740394276,"nanos":897312524},"severity":"TRACE","message":"fuse_debug: Op 0x00000166        connection.go:513] -> Error: \"stale file handle\""}
{"timestamp":{"seconds":1740394276,"nanos":897321854},"severity":"ERROR","message":"fuse: Op 0x00000166 *fuseops.SyncFileOp] Error: stale file handle"}
```

Now
```
{"timestamp":{"seconds":1740393686,"nanos":777589764},"severity":"TRACE","message":"fuse_debug: Op 0x00000168        connection.go:420] <- SyncFile (inode 2, PID 167380)"}
{"timestamp":{"seconds":1740393686,"nanos":808585082},"severity":"ERROR","message":"fuse: Op 0x00000168      *fuseops.SyncFileOp] -> Error: \"stale file handle\""}
```

More info: [b/398756683](https://b.corp.google.com/issues/398756683)
