### PR TITLE
Returning custom error while unmounting /dev/fd/N kind of mount point

### DIFF
--- a/unmount.go
+++ b/unmount.go
@@ -14,9 +14,7 @@
 
 package fuse
 
-import (
-	"errors"
-)
+import "errors"
 
 var ErrExternallyManagedMountPoint = errors.New("externally managed mount point, skipping unmount")
 

--- a/unmount_linux.go
+++ b/unmount_linux.go
@@ -8,14 +8,13 @@ import (
 )
 
 func unmount(dir string) error {
-	err := fuserunmount(dir)
-	if err != nil {
+	if err := fuserunmount(dir); err != nil {
 		// Return custom error for fusermount unmount error for /dev/fd/N mountpoints
 		if strings.HasPrefix(dir, "/dev/fd/") {
 			return fmt.Errorf("%w: %s", ErrExternallyManagedMountPoint, err)
 		}
 	}
-	return err
+	return nil
 }
 
 func fuserunmount(dir string) error {

--- a/unmount_linux_test.go
+++ b/unmount_linux_test.go
@@ -6,22 +6,18 @@ import (
 )
 
 func Test_umountExpectCustomError(t *testing.T) {
-	dir := "/dev/fd/42"
 	t.Setenv("PATH", "") // Clear PATH to fail unmount with fusermount is not found
 
-	err := unmount(dir)
-
+	err := unmount("/dev/fd/42")
 	if err == nil || !errors.Is(err, ErrExternallyManagedMountPoint) {
 		t.Errorf("Expected: %v, but got: %v", ErrExternallyManagedMountPoint, err)
 	}
 }
 
 func Test_umountNoCustomError(t *testing.T) {
-	dir := "/dev"
 	t.Setenv("PATH", "") // Clear PATH to fail unmount with fusermount is not found
 
-	err := unmount(dir)
-
+	err := unmount("/dev")
 	if err != nil && errors.Is(err, ErrExternallyManagedMountPoint) {
 		t.Errorf("Not expected custom error.")
 	}


### PR DESCRIPTION
**Issue:**
- Misleading error logs while unmount GCSFuse in GKE world, where mount is created externally and passed via GCSfuse in /dev/fd/N format.
```text
"Failed to unmount in response to SIGTERM: exec: \"fusermount\": executable file not found in $PATH
```
- This happens, as jacobsa/fuse library tries to unmount using fusermount binary, which is not present in GKE container environment and leads to failure. 

**Proposal:**
- Return a custom error during fuse.Unmount() so that file-system implementation can handle appropriately.

**Testing:**
Working as expected.