### PR TITLE
Add EnableAutoReaddirplus flag to MountConfig

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -208,8 +208,10 @@ func (c *Connection) Init() error {
 		// Enable Readdirplus support, allowing the kernel to use Readdirplus
 		initOp.Flags |= fusekernel.InitDoReaddirplus
 
-		// Enable adaptive Readdirplus, allowing the kernel to choose between Readdirplus and Readdir
-		initOp.Flags |= fusekernel.InitReaddirplusAuto
+		if c.cfg.EnableAutoReaddirplus {
+			// Enable adaptive Readdirplus, allowing the kernel to choose between Readdirplus and Readdir
+			initOp.Flags |= fusekernel.InitReaddirplusAuto
+		}
 	}
 
 	return c.Reply(ctx, nil)

--- a/mount_config.go
+++ b/mount_config.go
@@ -210,6 +210,18 @@ type MountConfig struct {
 	// by returning not just the directory entries (like ReadDir), but also their inode
 	// attributes, thereby saving one extra Lookup request per directory entry.
 	EnableReaddirplus bool
+
+	// Flag to enable adaptive ReadDirPlus.
+	// This is only effective if EnableReaddirplus is true.
+	//
+	// When both flags are set, the kernel may dynamically choose between issuing
+	// ReaddirPlus and Readdir requests based on observed access patterns.
+	// For example, `ls` (which lists filenames only) may fall back to Readdir after an initial ReaddirPlus,
+	// whereas `ls -l` is more likely to continue using ReaddirPlus.
+	//
+	// If EnableReaddirplus is true and this flag is false, the kernel will always
+	// use ReaddirPlus for directory listing.
+	EnableAutoReaddirplus bool
 }
 
 type FUSEImpl uint8


### PR DESCRIPTION
This change introduces a new EnableAutoReaddirplus flag to decouple the adaptive ReadDirPlus kernel behavior from the main EnableReaddirplus flag.

Problem:
Previously, enabling EnableReaddirplus would also enable the InitReaddirplusAuto kernel capability. The issue is that for a ls command, the adaptive mode results in the directory listing being performed twice:
The kernel first issues a ReadDirPlus request, optimistically fetching file attributes along with names.
When it sees that the user-space application (ls) does not use the attributes, it falls back and issues ReadDir requests which leads to listing the whole directory again.
This sequence leads to redundant work and unnecessary overhead.

The Solution
This pull request introduces a separate EnableAutoReaddirplus flag in the MountConfig. This decouples the adaptive behavior from the main feature, allowing for more precise control.

The logic is now as follows:
To force ReadDirPlus always: Set EnableReaddirplus: true and EnableAutoReaddirplus: false. This is ideal for workloads like ls -l where attributes are always needed.
To enable adaptive ReadDirPlus: Set both EnableReaddirplus: true and EnableAutoReaddirplus: true.

This change is implemented by making the setting of the fusekernel.InitReaddirplusAuto flag conditional on the new EnableAutoReaddirplus configuration