### PR TITLE
Check write permissions while mounting using fusermount

### DIFF
--- a/mount_linux.go
+++ b/mount_linux.go
@@ -149,7 +149,7 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 		// However, it doesn't give a useful error on mount-failure if the access is missing.
 		// So, add this check and return a useful error if the user doesn't have write-access.
 		if err := unix.Access(dir, unix.W_OK); err != nil {
-			return nil, fmt.Errorf("the user doesn't have permissions on the mount point: %w", err)
+			return nil, fmt.Errorf("the user doesn't have write-access on the mount point: %w", err)
 		}
 		argv := []string{
 			"-o", cfg.toOptionsString(),

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -160,6 +160,7 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 		if err2 := unix.Access(dir, unix.W_OK); err2 != nil {
 			return nil, errors.Join(err, fmt.Errorf("the user doesn't have write-access on the mount point: %w", err2))
 		}
+		return dev, err
 	}
 	return dev, err
 }

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -145,6 +145,11 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 		if err != nil {
 			return nil, err
 		}
+		// fusermount requires the runtime user to have write access to the directory.
+		// However, it doesn't give a useful error. So, check write access.
+		if err := unix.Access(dir, unix.W_OK); err != nil {
+			return nil, fmt.Errorf("the user doesn't have permissions on the mount point: %w", err)
+		}
 		argv := []string{
 			"-o", cfg.toOptionsString(),
 			"--",

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -145,8 +145,9 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 		if err != nil {
 			return nil, err
 		}
-		// fusermount requires the runtime user to have write access to the directory.
-		// However, it doesn't give a useful error. So, check write access.
+		// fusermount requires the mount user to have write access to the directory.
+		// However, it doesn't give a useful error on mount-failure if the access is missing.
+		// So, add this check and return a useful error if the user doesn't have write-access.
 		if err := unix.Access(dir, unix.W_OK); err != nil {
 			return nil, fmt.Errorf("the user doesn't have permissions on the mount point: %w", err)
 		}

--- a/mount_linux.go
+++ b/mount_linux.go
@@ -145,18 +145,21 @@ func mount(dir string, cfg *MountConfig, ready chan<- error) (*os.File, error) {
 		if err != nil {
 			return nil, err
 		}
-		// fusermount requires the mount user to have write access to the directory.
-		// However, it doesn't give a useful error on mount-failure if the access is missing.
-		// So, add this check and return a useful error if the user doesn't have write-access.
-		if err := unix.Access(dir, unix.W_OK); err != nil {
-			return nil, fmt.Errorf("the user doesn't have write-access on the mount point: %w", err)
-		}
 		argv := []string{
 			"-o", cfg.toOptionsString(),
 			"--",
 			dir,
 		}
-		return fusermount(fusermountPath, argv, []string{}, true, cfg.DebugLogger)
+		dev, err := fusermount(fusermountPath, argv, []string{}, true, cfg.DebugLogger)
+		if err == nil {
+			return dev, nil
+		}
+		// fusermount requires the mount user to have write access to the directory.
+		// However, it doesn't give a useful error on mount-failure if the access is missing.
+		// So, add this check and return a useful error if the user doesn't have write-access.
+		if err2 := unix.Access(dir, unix.W_OK); err2 != nil {
+			return nil, errors.Join(err, fmt.Errorf("the user doesn't have write-access on the mount point: %w", err2))
+		}
 	}
 	return dev, err
 }


### PR DESCRIPTION
fusermount doesn't let user mount unless they have write permissions on the mount-point([reference](https://man7.org/linux/man-pages/man8/mount.fuse3.8.html#SECURITY)). It also doesn't give an informative error in the output. Add a check to detect that the user has write access and return a useful error if they don't.