### PR TITLE
fix: false success in unmount flow

### DIFF
--- a/unmount_linux.go
+++ b/unmount_linux.go
@@ -13,6 +13,7 @@ func unmount(dir string) error {
 		if strings.HasPrefix(dir, "/dev/fd/") {
 			return fmt.Errorf("%w: %s", ErrExternallyManagedMountPoint, err)
 		}
+		return err
 	}
 	return nil
 }

--- a/unmount_linux_test.go
+++ b/unmount_linux_test.go
@@ -18,7 +18,7 @@ func Test_umountNoCustomError(t *testing.T) {
 	t.Setenv("PATH", "") // Clear PATH to fail unmount with fusermount is not found
 
 	err := unmount("/dev")
-	if err != nil && errors.Is(err, ErrExternallyManagedMountPoint) {
-		t.Errorf("Not expected custom error.")
+	if err == nil || errors.Is(err, ErrExternallyManagedMountPoint) {
+		t.Errorf("Expected error but not the custom error.")
 	}
 }

--- a/unmount_linux_test.go
+++ b/unmount_linux_test.go
@@ -18,7 +18,10 @@ func Test_umountNoCustomError(t *testing.T) {
 	t.Setenv("PATH", "") // Clear PATH to fail unmount with fusermount is not found
 
 	err := unmount("/dev")
-	if err == nil || errors.Is(err, ErrExternallyManagedMountPoint) {
-		t.Errorf("Expected error but not the custom error.")
+	if err == nil {
+		t.Fatal("Expected error but got none.")
+	}
+	if errors.Is(err, ErrExternallyManagedMountPoint) {
+		t.Error("Custom error was not expected.")
 	}
 }


### PR DESCRIPTION
Unmount flow started returning false success during the unmount after [this](https://github.com/jacobsa/fuse/pull/179).
