### PR TITLE
fix: throw error when ReadOp buffer allocation fails

### DIFF
--- a/conversions.go
+++ b/conversions.go
@@ -397,6 +397,9 @@ func convertInMessage(
 		}
 		// Use part of the incoming message storage as the read buffer.
 		to.Dst = inMsg.GetFree(int(in.Size))
+		if int(in.Size) > 0 && to.Dst == nil {
+			return nil, fmt.Errorf("cannot allocate read buffer for %d bytes", in.Size)
+		}
 		o = to
 
 	case fusekernel.OpReaddir:


### PR DESCRIPTION
This PR ensures that if the fuse library cannot allocate a sufficiently large buffer for an incoming `ReadOp`, it returns a clear error instead of passing a nil buffer up to the filesystem implementation.

This is a defensive check that we don't expect to ever hit. However, it'll prevent silent data corruption in case we do.

When this error is encountered, the mount becomes unusable and any attempts to access it will throw a `Transport endpoint is not connected` error. In GCSFuse, we'll see the following error:
```
panic: convertInMessage: cannot allocate read buffer for 4096 bytes

goroutine 101 [running]:
github.com/jacobsa/fuse/fuseutil.(*fileSystemServer).ServeOps(0x95de1915080, 0x95de1078400)
	/usr/local/google/home/kislayk/go/pkg/mod/github.com/kislaykishore/fuse-pool@v0.0.0-20260430182421-519a571b0849/fuseutil/file_system.go:114 +0x1e5
github.com/jacobsa/fuse.Mount.func1()
	/usr/local/google/home/kislayk/go/pkg/mod/github.com/kislaykishore/fuse-pool@v0.0.0-20260430182421-519a571b0849/mount.go:94 +0x32
created by github.com/jacobsa/fuse.Mount in goroutine 1
	/usr/local/google/home/kislayk/go/pkg/mod/github.com/kislaykishore/fuse-pool@v0.0.0-20260430182421-519a571b0849/mount.go:93 +0x5e9
exit status 2
```