### PR TITLE
Expose FUSE_ASYNC_DIO in MountConfig

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -168,6 +168,7 @@ func (c *Connection) Init() error {
 	cacheSymlinks := initOp.Flags&fusekernel.InitCacheSymlinks > 0
 	noOpenSupport := initOp.Flags&fusekernel.InitNoOpenSupport > 0
 	noOpendirSupport := initOp.Flags&fusekernel.InitNoOpendirSupport > 0
+	asyncDIO := initOp.Flags&fusekernel.InitAsyncDIO > 0
 
 	// Respond to the init op.
 	initOp.Library = c.protocol
@@ -181,6 +182,10 @@ func (c *Connection) Init() error {
 
 	if c.cfg.EnableAsyncReads {
 		initOp.Flags |= fusekernel.InitAsyncRead
+	}
+
+	if c.cfg.EnableAsyncDIO && asyncDIO {
+		initOp.Flags |= fusekernel.InitAsyncDIO
 	}
 
 	// kernel 4.20 increases the max from 32 -> 256

--- a/mount_config.go
+++ b/mount_config.go
@@ -188,9 +188,11 @@ type MountConfig struct {
 	// If not set, /proc/mounts will show the filesystem type as fuse/fuseblk.
 	Subtype string
 
-	// Flag to enable async reads that are received from
-	// the kernel
+	// Flag to enable async buffered reads
 	EnableAsyncReads bool
+
+	// Flag to enable async direct IO
+	EnableAsyncDIO bool
 
 	// Flag to enable parallel lookup and readdir operations from the
 	// kernel


### PR DESCRIPTION
When FUSE handles a read or write operation that is larger than the maximum FUSE message size it has to break up the request into multiple smaller ones. When this flag is set, FUSE will send these smaller requests in parallel to the FUSE server, which can then start the IO for all of them at the same time. This can significanlty increase throughput for remote file systems such as GCSFuse.

On current Linux kernels, the FUSE_ASYNC_DIO works for async IO (io_uring and libaio), but not for the traditional Posix read() and write() operations.